### PR TITLE
Persist filters on Project and Dataset pages

### DIFF
--- a/src/app/ui/pages/dataset/DatasetCard.jsx
+++ b/src/app/ui/pages/dataset/DatasetCard.jsx
@@ -1,4 +1,4 @@
-import { Box, Grid ,Button,Tooltip } from "@mui/material";
+import { Box, Grid, Button, Tooltip, Badge } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import DatasetCard from "@/components/common/DatasetCard";
 import DatasetStyle from "@/styles/dataset";
@@ -10,21 +10,21 @@ import { useNavigate } from "react-router-dom";
 import DatasetFilterList from "./DatasetFilterList";
 import FilterListIcon from "@mui/icons-material/FilterList";
 
-
 const DatasetCards = (props) => {
-    /* eslint-disable react-hooks/exhaustive-deps */
+  /* eslint-disable react-hooks/exhaustive-deps */
 
-  const { datasetList,selectedFilters,setsSelectedFilters } = props;
+  const { datasetList, selectedFilters, setsSelectedFilters } = props;
   const classes = DatasetStyle();
   const [page, setPage] = useState(0);
   const [loading, setLoading] = useState(false);
   const [rowsPerPage, setRowsPerPage] = useState(9);
   // const apiLoading = useSelector(state => state.apiStatus.loading);
-  const SearchDataset = useSelector((state) => state.searchProjectCard?.searchValue);
+  const SearchDataset = useSelector(
+    (state) => state.searchProjectCard?.searchValue,
+  );
   const [anchorEl, setAnchorEl] = useState(null);
   const popoverOpen = Boolean(anchorEl);
   const filterId = popoverOpen ? "simple-popover" : undefined;
- 
 
   const handleShowFilter = (event) => {
     setAnchorEl(event.currentTarget);
@@ -33,7 +33,6 @@ const DatasetCards = (props) => {
   const handleClose = () => {
     setAnchorEl(null);
   };
-
 
   const handleChangePage = (e, newPage) => {
     setPage(newPage);
@@ -70,17 +69,33 @@ const DatasetCards = (props) => {
   // useEffect(() => {
   //     setLoading(apiLoading);
   // }, [apiLoading])
+  const areFiltersApplied = (filters) => {
+    return Object.values(filters).some((value) => value !== "");
+  };
+
+  const filtersApplied = areFiltersApplied(selectedFilters);
+  console.log("filtersApplied", filtersApplied);
 
   return (
     <React.Fragment>
       {/* <Header /> */}
       {/* {loading && <Spinner />} */}
-      <Grid sx={{textAlign:"end",margin:"-20px 10px 10px 0px"}}>
+      <Grid sx={{ textAlign: "end", margin: "-20px 10px 10px 0px" }}>
         <Button style={{ minWidth: "25px" }} onClick={handleShowFilter}>
-        <Tooltip title={"Filter Table"}>
-          <FilterListIcon sx={{ color: "#515A5A" }} />
-        </Tooltip>
-      </Button>
+          <Badge
+            color="primary"
+            variant="dot"
+            invisible={!filtersApplied}
+            sx={{
+              position: "absolute",
+              top: 0,
+              right: 0,
+            }}
+          />
+          <Tooltip title={"Filter Table"}>
+            <FilterListIcon sx={{ color: "#515A5A" }} />
+          </Tooltip>
+        </Button>
       </Grid>
       {pageSearch().length > 0 && (
         <Box sx={{ margin: "0 auto", pb: 5 }}>

--- a/src/app/ui/pages/dataset/DatasetCardList.jsx
+++ b/src/app/ui/pages/dataset/DatasetCardList.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import MUIDataTable from "mui-datatables";
 import CustomButton from "@/components/common/Button";
-import { ThemeProvider,Tooltip, Button } from "@mui/material";
+import { ThemeProvider, Tooltip, Button, Badge } from "@mui/material";
 import tableTheme from "@/themes/tableTheme";
 import { useSelector } from "react-redux";
 import FilterListIcon from "@mui/icons-material/FilterList";
@@ -10,14 +10,15 @@ import DatasetFilterList from "./DatasetFilterList";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
 const DatasetCardList = (props) => {
-    /* eslint-disable react-hooks/exhaustive-deps */
+  /* eslint-disable react-hooks/exhaustive-deps */
 
-  const { datasetList,selectedFilters,setsSelectedFilters } = props;
-  const SearchDataset = useSelector((state) => state.searchProjectCard?.searchValue);
+  const { datasetList, selectedFilters, setsSelectedFilters } = props;
+  const SearchDataset = useSelector(
+    (state) => state.searchProjectCard?.searchValue,
+  );
   const [anchorEl, setAnchorEl] = useState(null);
   const popoverOpen = Boolean(anchorEl);
   const filterId = popoverOpen ? "simple-popover" : undefined;
- 
 
   const handleShowFilter = (event) => {
     setAnchorEl(event.currentTarget);
@@ -114,23 +115,43 @@ const DatasetCardList = (props) => {
         })
       : [];
 
+  const areFiltersApplied = (filters) => {
+    return Object.values(filters).some((value) => value !== "");
+  };
+
+  const filtersApplied = areFiltersApplied(selectedFilters);
+  console.log("filtersApplied", filtersApplied);
+
   const renderToolBar = () => {
     return (
-      <>
+      <div style={{ position: "relative" }}>
         {/* <Button style={{ minWidth: "25px" }} onClick={handleShowFilter}>
           <Tooltip title={"Filter Table"}>
             <FilterListIcon sx={{ color: "#515A5A" }} />
           </Tooltip>
         </Button> */}
-
-    <Button style={{ minWidth: '25px' }} onClick={handleShowFilter}>
-      <Tooltip 
-        title={<span style={{ fontFamily: 'Roboto, sans-serif' }}>Filter Table</span>}
-      >
-        <FilterListIcon sx={{ color: '#515A5A' }} />
-      </Tooltip>
-    </Button>
-      </>
+        <Badge
+          color="primary"
+          variant="dot"
+          invisible={!filtersApplied}
+          sx={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+          }}
+        />
+        <Button style={{ minWidth: "25px" }} onClick={handleShowFilter}>
+          <Tooltip
+            title={
+              <span style={{ fontFamily: "Roboto, sans-serif" }}>
+                Filter Table
+              </span>
+            }
+          >
+            <FilterListIcon sx={{ color: "#515A5A" }} />
+          </Tooltip>
+        </Button>
+      </div>
     );
   };
 

--- a/src/app/ui/pages/dataset/dataset.js
+++ b/src/app/ui/pages/dataset/dataset.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { Radio, Box, Grid, Typography, ThemeProvider } from "@mui/material";
 import RadioGroup from "@mui/material/RadioGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -16,7 +16,7 @@ import userRole from "@/utils/Role";
 import { fetchDatasets } from "@/Lib/Features/datasets/GetDatasets";
 
 export default function DatasetList() {
-      /* eslint-disable react-hooks/exhaustive-deps */
+  /* eslint-disable react-hooks/exhaustive-deps */
 
   const dispatch = useDispatch();
   const classes = DatasetStyle();
@@ -24,127 +24,153 @@ export default function DatasetList() {
   const [radiobutton, setRadiobutton] = useState(true);
   // const [loading, setLoading] = useState(false);
   const datasetList = useSelector((state) => state.GetDatasets.data);
-  const apiLoading = useSelector((state) => state.GetDatasets.status == "loading" );
-
-  const [selectedFilters, setsSelectedFilters] = useState({
-    dataset_visibility: "",
-    dataset_type: "",
-  });
-  console.log(selectedFilters);
-  const getDashboardprojectData = () => {
-    dispatch(fetchDatasets(selectedFilters));
-  };
-  
-  const loggedInUserData = useSelector(
-    (state) => state.getLoggedInData.data
+  const apiLoading = useSelector(
+    (state) => state.GetDatasets.status == "loading",
   );
 
+  // Initialize selected filters from localStorage or set default values
+  const [selectedFilters, setsSelectedFilters] = useState(() => {
+    const savedFilters = localStorage.getItem("datasetSelectedFilters");
+    return savedFilters
+      ? JSON.parse(savedFilters)
+      : { dataset_visibility: "", dataset_type: "" };
+  });
+
+  console.log(selectedFilters);
+
+  // Fetch datasets based on selected filters
+  const getDashboardprojectData = useCallback(() => {
+    dispatch(fetchDatasets(selectedFilters));
+  }, [dispatch, selectedFilters]);
+
+  const loggedInUserData = useSelector((state) => state.getLoggedInData.data);
 
   useEffect(() => {
     getDashboardprojectData();
+  }, [getDashboardprojectData]);
+
+  // Save selected filters to localStorage
+  useEffect(() => {
+    localStorage.setItem(
+      "datasetSelectedFilters",
+      JSON.stringify(selectedFilters),
+    );
   }, [selectedFilters]);
 
-  const handleProjectlist = () => {
+  // Handle view change to list
+  const handleProjectlist = useCallback(() => {
     setRadiobutton(true);
-  };
-  const handleProjectcard = () => {
+  }, []);
+
+  // Handle view change to card
+  const handleProjectcard = useCallback(() => {
     setRadiobutton(false);
-  };
-  const handleCreateProject = (e) => {
-    navigate(`/create-Dataset-Instance-Button/`);
-  };
-  //   useEffect(()=>{
-  //     getDatasetList();
-  // },[]);
+  }, []);
 
-  //   const handleCreateProject =(e)=>{
-  //       navigate(`/create-Dataset-Instance-Button/`)
-  //   }
+  // Handle create project button click
+  const handleCreateProject = useCallback(
+    (e) => {
+      navigate(`/create-Dataset-Instance-Button/`);
+    },
+    [navigate],
+  );
 
-  const handleAutomateButton = (e) => {
-    navigate("/datasets/automate");
-  };
-  
+  // Handle automate button click
+  const handleAutomateButton = useCallback(
+    (e) => {
+      navigate("/datasets/automate");
+    },
+    [navigate],
+  );
+
+  // Memoize dataset list to avoid unnecessary re-renders
+  const memoizedDatasetList = useMemo(() => datasetList, [datasetList]);
+
   return (
     <ThemeProvider theme={themeDefault}>
-      {apiLoading ? <Spinner /> : <> 
+      {apiLoading ? (
+        <Spinner />
+      ) : (
+        <>
+          <Grid container className={classes.root}>
+            <Grid item style={{ flexGrow: "0" }}>
+              <Typography variant="h6" sx={{ paddingBottom: "8px" }}>
+                View :{" "}
+              </Typography>
+            </Grid>
+            <Grid item style={{ flexGrow: "1", paddingLeft: "5px" }}>
+              <FormControl>
+                <RadioGroup
+                  row
+                  aria-labelledby="demo-row-radio-buttons-group-label"
+                  name="row-radio-buttons-group"
+                  defaultValue="DatasetList"
+                >
+                  <FormControlLabel
+                    value="DatasetList"
+                    control={<Radio />}
+                    label="List"
+                    onClick={handleProjectlist}
+                  />
+                  <FormControlLabel
+                    value="DatasetCard"
+                    control={<Radio />}
+                    label="Card"
+                    onClick={handleProjectcard}
+                  />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+            <Grid xs={3} item className={classes.fixedWidthContainer}>
+              <Search />
+            </Grid>
+          </Grid>
 
-      <Grid container className={classes.root}>
-        <Grid item style={{ flexGrow: "0" }}>
-          <Typography variant="h6" sx={{ paddingBottom: "8px" }}>
-            View :{" "}
-          </Typography>
-        </Grid>
-        <Grid item style={{ flexGrow: "1", paddingLeft: "5px" }}>
-          <FormControl>
-            <RadioGroup
-              row
-              aria-labelledby="demo-row-radio-buttons-group-label"
-              name="row-radio-buttons-group"
-              defaultValue="DatasetList"
-            >
-              <FormControlLabel
-                value="DatasetList"
-                control={<Radio />}
-                label="List"
-                onClick={handleProjectlist}
-              />
-              <FormControlLabel
-                value="DatasetCard"
-                control={<Radio />}
-                label="Card"
-                onClick={handleProjectcard}
-              />
-            </RadioGroup>
-          </FormControl>
-        </Grid>
-        <Grid xs={3} item className={classes.fixedWidthContainer}>
-          <Search />
-        </Grid>
-      </Grid>
-
-      <Box>
-        <CustomButton
-          sx={{
-            p: 2,
-            borderRadius: 3,
-            mt: 2,
-            mb: 2,
-            justifyContent: "flex-end",
-          }}
-          onClick={handleCreateProject}
-          label="Create New Dataset Instance"
-        />
-        <CustomButton
-          sx={{
-            p: 2,
-            borderRadius: 3,
-            mt: 2,
-            mb: 2,
-            ml: 2,
-            justifyContent: "flex-end",
-          }}
-          disabled = {userRole.Admin === loggedInUserData?.role? false : true}
-          onClick={handleAutomateButton}
-          label="Automate Datasets"
-        />
-        <Box sx={{ p: 1 }}>
-          {radiobutton ? (
-            <DatasetCardList
-              datasetList={datasetList}
-              selectedFilters={selectedFilters}
-              setsSelectedFilters={setsSelectedFilters}
+          <Box>
+            <CustomButton
+              sx={{
+                p: 2,
+                borderRadius: 3,
+                mt: 2,
+                mb: 2,
+                justifyContent: "flex-end",
+              }}
+              onClick={handleCreateProject}
+              label="Create New Dataset Instance"
             />
-          ) : (
-            <DatasetCard
-              datasetList={datasetList}
-              selectedFilters={selectedFilters}
-              setsSelectedFilters={setsSelectedFilters}
+            <CustomButton
+              sx={{
+                p: 2,
+                borderRadius: 3,
+                mt: 2,
+                mb: 2,
+                ml: 2,
+                justifyContent: "flex-end",
+              }}
+              disabled={
+                userRole.Admin === loggedInUserData?.role ? false : true
+              }
+              onClick={handleAutomateButton}
+              label="Automate Datasets"
             />
-          )}
-        </Box>
-      </Box>
-      </>}
+            <Box sx={{ p: 1 }}>
+              {radiobutton ? (
+                <DatasetCardList
+                  datasetList={memoizedDatasetList}
+                  selectedFilters={selectedFilters}
+                  setsSelectedFilters={setsSelectedFilters}
+                />
+              ) : (
+                <DatasetCard
+                  datasetList={memoizedDatasetList}
+                  selectedFilters={selectedFilters}
+                  setsSelectedFilters={setsSelectedFilters}
+                />
+              )}
+            </Box>
+          </Box>
+        </>
+      )}
     </ThemeProvider>
   );
 }

--- a/src/app/ui/pages/projects/project.js
+++ b/src/app/ui/pages/projects/project.js
@@ -1,7 +1,7 @@
-'use client'
-import  { React,useEffect, useState } from "react";
+"use client";
+import React, { useEffect, useState, useCallback } from "react";
 import { Radio, Box, Grid, Typography, ThemeProvider } from "@mui/material";
-import { useTheme } from '@mui/material/styles';
+import { useTheme } from "@mui/material/styles";
 import RadioGroup from "@mui/material/RadioGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormControl from "@mui/material/FormControl";
@@ -9,94 +9,121 @@ import ProjectCardList from "@/components/Project/ProjectCardList";
 import ProjectCard from "@/components/Project/ProjectCard";
 import Spinner from "@/components/common/Spinner";
 import Search from "@/components/common/Search";
-import  "@/styles/Dataset.css";
+import "@/styles/Dataset.css";
 import themeDefault from "@/themes/theme";
 import { useDispatch, useSelector } from "react-redux";
 import tableTheme from "@/themes/tableTheme";
 import { fetchProjects } from "@/Lib/Features/projects/getProjects";
 import { FetchLoggedInUserData } from "@/Lib/Features/getLoggedInData";
 
-export default function ProjectList({data}) {
-         /* eslint-disable react-hooks/exhaustive-deps */
-           /* eslint-disable-next-line react/jsx-key */
+const ProjectList = React.memo(({ data }) => {
+  const dispatch = useDispatch();
+  const [radiobutton, setRadiobutton] = useState(true);
+  const theme = useTheme();
 
-           
-const dispatch = useDispatch();
-const [radiobutton, setRadiobutton] = useState(true);
-console.log(data);
-const theme = useTheme();
-
-
-  // const [loading, setLoading] = useState(true);
-  const [selectedFilters, setsSelectedFilters] = useState({
-    project_type: "",
-    project_user_type: "",
-    archived_projects: "",
+  // Initialize selected filters from localStorage or set default values
+  const [selectedFilters, setsSelectedFilters] = useState(() => {
+    const savedFilters = localStorage.getItem("projectSelectedFilters");
+    return savedFilters
+      ? JSON.parse(savedFilters)
+      : {
+          project_type: "",
+          project_user_type: "",
+          archived_projects: "",
+        };
   });
-  const [guestworkspace, setguestworkspace] = useState(false);
-  const loggedInUserData = useSelector(state => state.getLoggedInData?.data);
-  const apiLoading = useSelector((state) => state.getProjects.status === "loading");
-  const projectData = useSelector((state) => state.getProjects.data);
-  console.log(projectData);
-  useEffect(() => {
-       dispatch(FetchLoggedInUserData("me"));
-  },[]);
 
-   useEffect(() => {
-      if (loggedInUserData ) {
-      if (loggedInUserData?.guest_user==true) {
+  const [guestworkspace, setguestworkspace] = useState(false);
+  const loggedInUserData = useSelector((state) => state.getLoggedInData?.data);
+  const apiLoading = useSelector(
+    (state) => state.getProjects.status === "loading",
+  );
+  const projectData = useSelector((state) => state.getProjects.data);
+
+  // Fetch logged-in user data
+  const fetchUserData = useCallback(() => {
+    dispatch(FetchLoggedInUserData("me"));
+  }, [dispatch]);
+
+  useEffect(() => {
+    fetchUserData();
+  }, [fetchUserData]);
+
+  // Fetch projects based on selected filters and user data
+  useEffect(() => {
+    if (loggedInUserData) {
+      if (loggedInUserData?.guest_user == true) {
         console.log(loggedInUserData.guest_user);
         setguestworkspace(true);
       }
-      dispatch(fetchProjects({ selectedFilters: selectedFilters, guestworkspace: guestworkspace }));
-      
+      dispatch(
+        fetchProjects({
+          selectedFilters: selectedFilters,
+          guestworkspace: guestworkspace,
+        }),
+      );
     }
-  }, [selectedFilters,loggedInUserData]);
+  }, [selectedFilters, loggedInUserData]);
 
-console.log(data?.length,"hel");
+  // Save selected filters to localStorage
+  useEffect(() => {
+    localStorage.setItem(
+      "projectSelectedFilters",
+      JSON.stringify(selectedFilters),
+    );
+  }, [selectedFilters]);
 
-
+  // Handle view change to list
   const handleProjectlist = () => {
     setRadiobutton(true);
   };
+
+  // Handle view change to card
   const handleProjectcard = () => {
     setRadiobutton(false);
   };
+
+  // Determine which projects to display
   const displayedProjects = data?.length > 0 ? data : projectData || [];
+
   return (
     <ThemeProvider theme={themeDefault}>
-      {apiLoading ? <Spinner /> :  
-      <>
-      <Grid container className="root" >
-
-        <Grid item style={{ flexGrow: "0" }} >
-          <Typography variant="h6" sx={{ paddingBottom: "7px" ,paddingLeft: "15px"}}>
-            View :{" "}
-          </Typography>
-        </Grid>
-        <Grid item style={{ flexGrow: "1", paddingLeft: "5px" }}>
-          <FormControl>
-            <RadioGroup
-              row
-              aria-labelledby="demo-row-radio-buttons-group-label"
-              name="row-radio-buttons-group"
-              defaultValue="ProjectList"
-            >
-              <FormControlLabel
-                value="ProjectList"
-                control={<Radio />}
-                label="List"
-                onClick={handleProjectlist}
-              />
-              <FormControlLabel
-                value="ProjectCard"
-                control={<Radio />}
-                label="Card"
-                onClick={handleProjectcard}
-              />
-            </RadioGroup>
-          </FormControl>
-        </Grid>
+      {apiLoading ? (
+        <Spinner />
+      ) : (
+        <>
+          <Grid container className="root">
+            <Grid item style={{ flexGrow: "0" }}>
+              <Typography
+                variant="h6"
+                sx={{ paddingBottom: "7px", paddingLeft: "15px" }}
+              >
+                View :{" "}
+              </Typography>
+            </Grid>
+            <Grid item style={{ flexGrow: "1", paddingLeft: "5px" }}>
+              <FormControl>
+                <RadioGroup
+                  row
+                  aria-labelledby="demo-row-radio-buttons-group-label"
+                  name="row-radio-buttons-group"
+                  defaultValue="ProjectList"
+                >
+                  <FormControlLabel
+                    value="ProjectList"
+                    control={<Radio />}
+                    label="List"
+                    onClick={handleProjectlist}
+                  />
+                  <FormControlLabel
+                    value="ProjectCard"
+                    control={<Radio />}
+                    label="Card"
+                    onClick={handleProjectcard}
+                  />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
 
             <Grid
               item
@@ -112,25 +139,27 @@ console.log(data?.length,"hel");
             </Grid>
           </Grid>
 
-      <Box>
-        <Box sx={{ margin: "20px" }}>
-          {radiobutton ? (
-            <ProjectCardList
-              projectData={displayedProjects}
-              selectedFilters={selectedFilters} 
-              setsSelectedFilters={setsSelectedFilters} 
-            />
-          ) : (
-            <ProjectCard 
-            projectData={displayedProjects}
-             selectedFilters={selectedFilters} 
-            setsSelectedFilters={setsSelectedFilters}
-              />
-          )}
-        </Box>
-      </Box>
-      </>
-      }
+          <Box>
+            <Box sx={{ margin: "20px" }}>
+              {radiobutton ? (
+                <ProjectCardList
+                  projectData={displayedProjects}
+                  selectedFilters={selectedFilters}
+                  setsSelectedFilters={setsSelectedFilters}
+                />
+              ) : (
+                <ProjectCard
+                  projectData={displayedProjects}
+                  selectedFilters={selectedFilters}
+                  setsSelectedFilters={setsSelectedFilters}
+                />
+              )}
+            </Box>
+          </Box>
+        </>
+      )}
     </ThemeProvider>
-  );
-}
+  );
+});
+
+export default ProjectList;

--- a/src/components/Project/ProjectCard.jsx
+++ b/src/components/Project/ProjectCard.jsx
@@ -1,8 +1,22 @@
-import { Box, Grid,Button,Tooltip,Typography, Dialog, DialogTitle, TextField, FormHelperText, InputAdornment, IconButton, DialogActions } from "@mui/material";
+import {
+  Box,
+  Grid,
+  Button,
+  Tooltip,
+  Typography,
+  Dialog,
+  DialogTitle,
+  TextField,
+  FormHelperText,
+  InputAdornment,
+  IconButton,
+  DialogActions,
+  Badge,
+} from "@mui/material";
 import React, { useEffect, useState } from "react";
 import ProjectCard from "../common/ProjectCard";
 import { Link, useNavigate } from "react-router-dom";
-import  "../../styles/Dataset.css";
+import "../../styles/Dataset.css";
 import DatasetStyle from "@/styles/dataset";
 import { useDispatch, useSelector } from "react-redux";
 import TablePagination from "@mui/material/TablePagination";
@@ -18,27 +32,35 @@ import { DialogContent } from "@mui/material";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import VerifyProject from "@/app/actions/api/Projects/VerifyProject";
 
-
 const Projectcard = (props) => {
-       /* eslint-disable react-hooks/exhaustive-deps */
-           /* eslint-disable-next-line react/jsx-key */
+  /* eslint-disable react-hooks/exhaustive-deps */
+  /* eslint-disable-next-line react/jsx-key */
 
   const { projectData, selectedFilters, setsSelectedFilters } = props;
   const classes = DatasetStyle();
-  const SearchProject = useSelector((state) => state.searchProjectCard?.searchValue);
+  const SearchProject = useSelector(
+    (state) => state.searchProjectCard?.searchValue,
+  );
   const [page, setPage] = useState(0);
   const navigate = useNavigate();
   const [rowsPerPage, setRowsPerPage] = useState(9);
   const [anchorEl, setAnchorEl] = useState(null);
   const popoverOpen = Boolean(anchorEl);
   const filterId = popoverOpen ? "simple-popover" : undefined;
-  const combinedData = (projectData.included_projects && projectData.excluded_projects) ? projectData.excluded_projects.concat(projectData.included_projects) : projectData
-  const loggedInUserData = useSelector(state => state.getLoggedInData?.data);
+  const combinedData =
+    projectData.included_projects && projectData.excluded_projects
+      ? projectData.excluded_projects.concat(projectData.included_projects)
+      : projectData;
+  const loggedInUserData = useSelector((state) => state.getLoggedInData?.data);
   const [openAuthDialog, setOpenAuthDialog] = useState(false);
   const [selectedProject, setSelectedProject] = useState(null);
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
-  const [snackbarInfo, setSnackbarInfo] = useState({ open: false, message: '', variant: '' });
+  const [snackbarInfo, setSnackbarInfo] = useState({
+    open: false,
+    message: "",
+    variant: "",
+  });
   const handleShowFilter = (event) => {
     setAnchorEl(event.currentTarget);
   };
@@ -57,12 +79,10 @@ const Projectcard = (props) => {
     setOpenAuthDialog(true);
   };
 
-
   const rowChange = (e) => {
     setRowsPerPage(parseInt(e.target.value, 10));
     setPage(0);
   };
-
 
   const handlePasswordSubmit = async () => {
     const apiObj = new VerifyProject(selectedProject?.id, password);
@@ -85,12 +105,10 @@ const Projectcard = (props) => {
         variant: "error",
       });
     }
-    navigate(`/projects/${selectedProject?.id}`)
+    navigate(`/projects/${selectedProject?.id}`);
     handleAuthClose();
   };
 
-
- 
   const pageSearch = () => {
     return combinedData.filter((el) => {
       if (SearchProject == "") {
@@ -99,7 +117,7 @@ const Projectcard = (props) => {
         el.project_type?.toLowerCase().includes(SearchProject?.toLowerCase())
       ) {
         return el;
-      }  else if (
+      } else if (
         el.title?.toLowerCase().includes(SearchProject?.toLowerCase())
       ) {
         return el;
@@ -107,21 +125,24 @@ const Projectcard = (props) => {
         el.id.toString()?.toLowerCase()?.includes(SearchProject.toLowerCase())
       ) {
         return el;
-      }else if (
-        el.workspace_id.toString()?.toLowerCase().includes(SearchProject?.toLowerCase())
+      } else if (
+        el.workspace_id
+          .toString()
+          ?.toLowerCase()
+          .includes(SearchProject?.toLowerCase())
       ) {
-        return el;}
-        else if (
-          el.tgt_language?.toLowerCase().includes(SearchProject?.toLowerCase())
-        ) {
-          return el;}
-          else if (
-            UserMappedByProjectStage(el.project_stage)
-              ?.name?.toLowerCase()
-              .includes(SearchProject?.toLowerCase())
-          ) {
-            return el;
-          }
+        return el;
+      } else if (
+        el.tgt_language?.toLowerCase().includes(SearchProject?.toLowerCase())
+      ) {
+        return el;
+      } else if (
+        UserMappedByProjectStage(el.project_stage)
+          ?.name?.toLowerCase()
+          .includes(SearchProject?.toLowerCase())
+      ) {
+        return el;
+      }
     });
   };
 
@@ -135,17 +156,33 @@ const Projectcard = (props) => {
     setPassword("");
   };
 
+  const areFiltersApplied = (filters) => {
+    return Object.values(filters).some((value) => value !== "");
+  };
+
+  const filtersApplied = areFiltersApplied(selectedFilters);
+  console.log("filtersApplied", filtersApplied);
 
   return (
     <React.Fragment>
       {/* <Header /> */}
       {/* {loading && <Spinner />} */}
-      <Grid sx={{textAlign:"end",margin:"-20px 10px 10px 0px"}}>
+      <Grid sx={{ textAlign: "end", margin: "-10px 10px 10px 0px" }}>
         <Button style={{ minWidth: "25px" }} onClick={handleShowFilter}>
-        <Tooltip title={"Filter Table"}>
-          <FilterListIcon sx={{ color: "#515A5A" }} />
-        </Tooltip>
-      </Button>
+          <Badge
+            color="primary"
+            variant="dot"
+            invisible={!filtersApplied}
+            sx={{
+              position: "absolute",
+              top: 0,
+              right: 0,
+            }}
+          />
+          <Tooltip title={"Filter Table"}>
+            <FilterListIcon sx={{ color: "#515A5A" }} />
+          </Tooltip>
+        </Button>
       </Grid>
       {pageSearch().length > 0 && (
         <Box sx={{ margin: "0 auto", pb: 5 }}>
@@ -163,17 +200,17 @@ const Projectcard = (props) => {
                 return (
                   <Grid key={el.id} item xs={12} sm={6} md={4} lg={4} xl={4}>
                     {/* <div onClick={() => handleCardClick(el)}> */}
-                      <ProjectCard
-                        classAssigned={
-                          i % 2 === 0
-                            ? classes.projectCardContainer2
-                            : classes.projectCardContainer1
-                        }
-                        projectObj={el}
-                        projectData={projectData}
-                        handleAuthOpen={handleAuthOpen}
-                        index={i}
-                      />
+                    <ProjectCard
+                      classAssigned={
+                        i % 2 === 0
+                          ? classes.projectCardContainer2
+                          : classes.projectCardContainer1
+                      }
+                      projectObj={el}
+                      projectData={projectData}
+                      handleAuthOpen={handleAuthOpen}
+                      index={i}
+                    />
                     {/* </div> */}
                   </Grid>
                 );
@@ -200,7 +237,7 @@ const Projectcard = (props) => {
         updateFilters={setsSelectedFilters}
         currentFilters={selectedFilters}
       />
-            <Dialog open={openAuthDialog} onClose={handleAuthClose}>
+      <Dialog open={openAuthDialog} onClose={handleAuthClose}>
         <DialogTitle>Enter Password</DialogTitle>
         <DialogContent>
           <TextField
@@ -241,7 +278,6 @@ const Projectcard = (props) => {
           </Button>
         </DialogActions>
       </Dialog>
-
     </React.Fragment>
   );
 };

--- a/src/components/Project/ProjectCardList.jsx
+++ b/src/components/Project/ProjectCardList.jsx
@@ -1,10 +1,23 @@
-import  {React, useState, useEffect } from "react";
+import { React, useState, useEffect } from "react";
 // import Link from 'next/link';
-import { ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider } from "@mui/material/styles";
 import MUIDataTable from "mui-datatables";
 import CustomButton from "../common/Button";
 import { Link, useNavigate } from "react-router-dom";
-import { Grid, Tooltip, Button, Dialog, DialogTitle, DialogContent, TextField, FormHelperText, Typography, IconButton, InputAdornment } from "@mui/material";
+import {
+  Grid,
+  Tooltip,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  FormHelperText,
+  Typography,
+  IconButton,
+  InputAdornment,
+  Badge,
+} from "@mui/material";
 import tableTheme from "../../themes/tableTheme";
 import Search from "../common/Search";
 import { useDispatch, useSelector } from "react-redux";
@@ -17,8 +30,8 @@ import VerifyProject from "@/app/actions/api/Projects/VerifyProject";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 
 const ProjectCardList = (props) => {
-         /* eslint-disable react-hooks/exhaustive-deps */
-           /* eslint-disable-next-line react/jsx-key */
+  /* eslint-disable react-hooks/exhaustive-deps */
+  /* eslint-disable-next-line react/jsx-key */
 
   const { projectData, selectedFilters, setsSelectedFilters } = props;
   const [anchorEl, setAnchorEl] = useState(null);
@@ -28,24 +41,33 @@ const ProjectCardList = (props) => {
   const [password, setPassword] = useState("");
   const [openAuthDialog, setOpenAuthDialog] = useState(false);
   const [selectedProject, setSelectedProject] = useState(null);
-  const loggedInUserData = useSelector(state => state.getLoggedInData?.data);
+  const loggedInUserData = useSelector((state) => state.getLoggedInData?.data);
   const [showPassword, setShowPassword] = useState(false);
-  const [snackbarInfo, setSnackbarInfo] = useState({ open: false, message: '', variant: '' });
-  const combinedData = (projectData.included_projects && projectData.excluded_projects) ? projectData.excluded_projects.concat(projectData.included_projects).sort((a, b) => a.id - b.id) : projectData
+  const [snackbarInfo, setSnackbarInfo] = useState({
+    open: false,
+    message: "",
+    variant: "",
+  });
+  const combinedData =
+    projectData.included_projects && projectData.excluded_projects
+      ? projectData.excluded_projects
+          .concat(projectData.included_projects)
+          .sort((a, b) => a.id - b.id)
+      : projectData;
   const navigate = useNavigate();
-  const SearchProject = useSelector((state) => state.searchProjectCard?.searchValue);
+  const SearchProject = useSelector(
+    (state) => state.searchProjectCard?.searchValue,
+  );
 
   const handleShowFilter = (event) => {
     setAnchorEl(event.currentTarget);
   };
-  
-
 
   const handleClose = () => {
     setAnchorEl(null);
   };
 
-  const handleAuthOpen = (project,title) => {
+  const handleAuthOpen = (project, title) => {
     setSelectedProject(project);
     setOpenAuthDialog(true);
   };
@@ -59,9 +81,13 @@ const ProjectCardList = (props) => {
     setShowPassword(!showPassword);
   };
 
-  const handlePasswordSubmit = async() => {
+  const handlePasswordSubmit = async () => {
     console.log(selectedProject?.id);
-    const apiObj = new VerifyProject(loggedInUserData?.id,selectedProject?.id,password);
+    const apiObj = new VerifyProject(
+      loggedInUserData?.id,
+      selectedProject?.id,
+      password,
+    );
     const res = await fetch(apiObj.apiEndPoint(), {
       method: "POST",
       body: JSON.stringify(apiObj.getBody()),
@@ -74,15 +100,15 @@ const ProjectCardList = (props) => {
         open: true,
         message: resp?.message,
         variant: "success",
-      })
+      });
     } else {
       setSnackbarInfo({
         open: true,
         message: resp?.message,
         variant: "error",
-      })
-    }  
-    navigate(`/projects/${selectedProject?.id}`)
+      });
+    }
+    navigate(`/projects/${selectedProject?.id}`);
     handleAuthClose();
   };
   const pageSearch = () => {
@@ -216,10 +242,13 @@ const ProjectCardList = (props) => {
             el.project_stage &&
             UserMappedByProjectStage(el.project_stage).element;
 
-            const isExcluded = projectData && projectData.excluded_projects && projectData.excluded_projects?.some(
-              (excludedProject) => excludedProject.id === el.id
+          const isExcluded =
+            projectData &&
+            projectData.excluded_projects &&
+            projectData.excluded_projects?.some(
+              (excludedProject) => excludedProject.id === el.id,
             );
-    
+
           return [
             el.id,
             el.title,
@@ -233,10 +262,14 @@ const ProjectCardList = (props) => {
                 key={i}
                 sx={{ borderRadius: 2, marginRight: 2 }}
                 label="Authenticate"
-                onClick={() => handleAuthOpen(el,el.title)}
+                onClick={() => handleAuthOpen(el, el.title)}
               />
             ) : (
-              <Link to={`/projects/${el.id}`} style={{ textDecoration: "none" }} key={i}>
+              <Link
+                to={`/projects/${el.id}`}
+                style={{ textDecoration: "none" }}
+                key={i}
+              >
                 <CustomButton
                   key={i}
                   sx={{ borderRadius: 2, marginRight: 2 }}
@@ -248,27 +281,51 @@ const ProjectCardList = (props) => {
         })
       : [];
 
+  const areFiltersApplied = (filters) => {
+    return Object.values(filters).some((value) => value !== "");
+  };
+
+  const filtersApplied = areFiltersApplied(selectedFilters);
+  console.log("filtersApplied", filtersApplied);
+
   const renderToolBar = () => {
     return (
-      <>
-        <Button style={{ minWidth: "25px" }} onClick={handleShowFilter}>
+      <div
+        style={{
+          position: "relative",
+        }}
+      >
+        <Badge
+          color="primary"
+          variant="dot"
+          invisible={!filtersApplied}
+          sx={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+          }}
+        />
         <Tooltip
-      title={
-        <span style={{ fontFamily: 'Roboto, sans-serif' }}>
-          Filter Table
-        </span>
-      }
-    >
-      <FilterListIcon sx={{ color: '#515A5A' }} />
-    </Tooltip>
-        </Button>
-      </>
+          title={
+            <span style={{ fontFamily: "Roboto, sans-serif" }}>
+              Filter Table
+            </span>
+          }
+        >
+          <Button
+            style={{ minWidth: "25px", position: "relative" }}
+            onClick={handleShowFilter}
+          >
+            <FilterListIcon sx={{ color: "#515A5A" }} />
+          </Button>
+        </Tooltip>
+      </div>
     );
   };
+
   const handleMouseDownPassword = (event) => {
     event.preventDefault();
   };
-
 
   const options = {
     textLabels: {
@@ -340,15 +397,10 @@ const ProjectCardList = (props) => {
               ),
             }}
             onChange={(e) => setPassword(e.target.value)}
-
           />
           <FormHelperText id="enter-password">
-            To enter {" "}
-            <Typography
-              component="span"
-              fontWeight="bold"
-              fontSize={"12px"}
-            >
+            To enter{" "}
+            <Typography component="span" fontWeight="bold" fontSize={"12px"}>
               {selectedProject?.title}
             </Typography>{" "}
             project you must type in the password.
@@ -363,7 +415,6 @@ const ProjectCardList = (props) => {
           </Button>
         </DialogActions>
       </Dialog>
-
     </>
   );
 };

--- a/src/components/common/ProjectFilterList.jsx
+++ b/src/components/common/ProjectFilterList.jsx
@@ -23,30 +23,26 @@ import roles from "../../utils/Role";
 import { snakeToTitleCase } from "@/utils/utils";
 import { fetchProjectDomains } from "@/Lib/Features/getProjectDomains";
 
-const UserType = ["annotator", "reviewer","superchecker"];
+const UserType = ["annotator", "reviewer", "superchecker"];
 const archivedProjects = ["true", "false"];
 const ProjectFilterList = (props) => {
   const classes = DatasetStyle();
   const dispatch = useDispatch();
-  const {
-    filterStatusData,
-    currentFilters,
-    updateFilters,
-  
-  } = props;
-
-
-  
+  const { filterStatusData, currentFilters, updateFilters } = props;
 
   const [projectTypes, setProjectTypes] = useState([]);
-  const [selectedType, setSelectedType] = useState(currentFilters.project_type || "");
-  const [selectedUserType, setSelectedUserType] = useState(currentFilters.project_user_type || "");
-  const [selectedArchivedProject, setSelectedArchivedProject] = useState(currentFilters.archived_projects || "");
-  
-  const ProjectTypes = useSelector((state) => state.getProjectDomains.data);
-  const loggedInUserData = useSelector(
-    (state) => state.getLoggedInData.data
+  const [selectedType, setSelectedType] = useState(
+    currentFilters.project_type || "",
   );
+  const [selectedUserType, setSelectedUserType] = useState(
+    currentFilters.project_user_type || "",
+  );
+  const [selectedArchivedProject, setSelectedArchivedProject] = useState(
+    currentFilters.archived_projects || "",
+  );
+
+  const ProjectTypes = useSelector((state) => state.getProjectDomains.data);
+  const loggedInUserData = useSelector((state) => state.getLoggedInData.data);
   useEffect(() => {
     dispatch(fetchProjectDomains());
   }, [dispatch]);
@@ -61,7 +57,6 @@ const ProjectFilterList = (props) => {
       });
     }
     setProjectTypes(types);
-    
   }, [ProjectTypes]);
 
   const handleChange = (e) => {
@@ -76,14 +71,13 @@ const ProjectFilterList = (props) => {
 
   const handleChangeCancelAll = () => {
     updateFilters({
-        project_type: "",
-        project_user_type: "",
-        archived_projects: "",
-     
+      project_type: "",
+      project_user_type: "",
+      archived_projects: "",
     });
-    setSelectedType("")
-    setSelectedUserType("")
-    setSelectedArchivedProject("")
+    setSelectedType("");
+    setSelectedUserType("");
+    setSelectedArchivedProject("");
     props.handleClose();
   };
   return (
@@ -103,44 +97,51 @@ const ProjectFilterList = (props) => {
         }}
       >
         <Grid container className={classes.filterContainer}>
-          <Grid item xs={11} sm={11} md={11 } lg={11} xl={11} sx={{width:"130px"}} >
-          <FormControl fullWidth size="small" >
-            <InputLabel id="project-type-label" sx={{ fontSize: "16px" }}>Project Type</InputLabel>
-            <Select
-              labelId="project-type-label"
-              id="project-type-select"
-              value={selectedType}
-              label="Project Type"
-              onChange={(e) => setSelectedType(e.target.value)}
-             
-            >
-              {projectTypes.map((type, index) => (
-                <MenuItem key={index} value={type} >
-                  {type}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          
-
+          <Grid
+            item
+            xs={11}
+            sm={11}
+            md={11}
+            lg={11}
+            xl={11}
+            sx={{ width: "130px" }}
+          >
+            <FormControl fullWidth size="small">
+              <InputLabel id="project-type-label" sx={{ fontSize: "16px" }}>
+                Project Type
+              </InputLabel>
+              <Select
+                labelId="project-type-label"
+                id="project-type-select"
+                value={selectedType}
+                label="Project Type"
+                onChange={(e) => setSelectedType(e.target.value)}
+              >
+                {projectTypes.map((type, index) => (
+                  <MenuItem key={index} value={type}>
+                    {type}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
           </Grid>
-       
-          <Grid item xs={6} sm={6} md={6} lg={6} xl={6} sx={{mt:2}}>
+
+          <Grid item xs={6} sm={6} md={6} lg={6} xl={6} sx={{ mt: 2 }}>
             <Typography
               variant="body2"
-              sx={{  mb: 1, fontWeight: "900",width:"120px" }}
+              sx={{ mb: 1, fontWeight: "900", width: "120px" }}
             >
               Project User Type :
             </Typography>
             <FormGroup>
-              {UserType.map((type,i) => {
+              {UserType.map((type, i) => {
                 return (
                   <FormControlLabel
                     key={i}
                     control={
                       <Radio
                         key={i}
-                        checked={selectedUserType === type }
+                        checked={selectedUserType === type}
                         name={type}
                         color="primary"
                       />
@@ -156,40 +157,43 @@ const ProjectFilterList = (props) => {
               })}
             </FormGroup>
           </Grid>
-          {(roles?.WorkspaceManager === loggedInUserData?.role || roles?.OrganizationOwner === loggedInUserData?.role || roles?.Admin === loggedInUserData?.role )  &&
-          <Grid item xs={5} sm={5} md={5} lg={5} xl={5} sx={{mt:2}}>
-            <Typography
-              variant="body2"
-              sx={{ mr: 5, mb: 1, fontWeight: "900" }}
-              className={classes.filterTypo}
-            >
-              Archived Projects :
-            </Typography>
-            <FormGroup>
-              {archivedProjects.map((type, i) => {
-                return (
-                  <FormControlLabel
-                    key={i}
-                    control={
-                      <Radio
-                        checked={
-                          selectedArchivedProject === type 
-                        }
-                        name={type}
-                        color="primary"
-                      />
-                    }
-                    onChange={(e) => setSelectedArchivedProject(e.target.value)}
-                    value={type}
-                    label={snakeToTitleCase(type)}
-                    sx={{
-                      fontSize: "1rem",
-                    }}
-                  />
-                );
-              })}
-            </FormGroup>
-          </Grid>}
+          {(roles?.WorkspaceManager === loggedInUserData?.role ||
+            roles?.OrganizationOwner === loggedInUserData?.role ||
+            roles?.Admin === loggedInUserData?.role) && (
+            <Grid item xs={5} sm={5} md={5} lg={5} xl={5} sx={{ mt: 2 }}>
+              <Typography
+                variant="body2"
+                sx={{ mr: 5, mb: 1, fontWeight: "900" }}
+                className={classes.filterTypo}
+              >
+                Archived Projects :
+              </Typography>
+              <FormGroup>
+                {archivedProjects.map((type, i) => {
+                  return (
+                    <FormControlLabel
+                      key={i}
+                      control={
+                        <Radio
+                          checked={selectedArchivedProject === type}
+                          name={type}
+                          color="primary"
+                        />
+                      }
+                      onChange={(e) =>
+                        setSelectedArchivedProject(e.target.value)
+                      }
+                      value={type}
+                      label={snakeToTitleCase(type)}
+                      sx={{
+                        fontSize: "1rem",
+                      }}
+                    />
+                  );
+                })}
+              </FormGroup>
+            </Grid>
+          )}
         </Grid>
         <Divider />
         <Box
@@ -199,7 +203,7 @@ const ProjectFilterList = (props) => {
             justifyContent: "flex-end",
             alignItems: "center",
             columnGap: "10px",
-            padding:"15px"
+            padding: "15px",
           }}
         >
           <Button


### PR DESCRIPTION
**Projects & Datasets Page Updates:**

1. Used "memo" and "callback" hooks for optimisation of the rendering and stopping unnecessary re-renders.

2. Implemented filter persistence using "Local Storage" so that users' filter settings are persisted across page reloads and sessions.

3. Added "badges" for card and list views on the filter button to enhance users' experience and better visibility of the active filters.