### PR TITLE
User preference UI Customization and endpoint 'update_ui_prefs' is disabled

### DIFF
--- a/src/Lib/Features/user/UpdateUIPrefs.js
+++ b/src/Lib/Features/user/UpdateUIPrefs.js
@@ -4,9 +4,15 @@ import ENDPOINTS from "../../../config/apiendpoint"
 import constants from "@/Constants/constants";
 
 export default class UpdateUIPrefsAPI extends API {
-    constructor(preferUI, timeout = 2000) {
+    /**
+     * @param {Object} payload - Any subset of:
+     *   { prefer_cl_ui, instruction_panel_width, annotation_font_size, instruction_panel_pinned }
+     */
+    constructor(payload, timeout = 2000) {
         super("POST", timeout, false);
-        this.preferUI = preferUI;
+        this.payload = typeof payload === "boolean"
+            ? { prefer_cl_ui: payload }  // backward-compat: old callers pass a bool directly
+            : payload;
         this.type = constants.UPDATE_UI_PREFS;
         this.endpoint = `${super.apiEndPointAuto()}${ENDPOINTS.fetch}update_ui_prefs/`;
     }
@@ -20,9 +26,7 @@ export default class UpdateUIPrefsAPI extends API {
     }
 
     getBody() {
-        return {
-            prefer_cl_ui: this.preferUI,
-        }
+        return this.payload;
     }
 
     getHeaders() {
@@ -36,6 +40,6 @@ export default class UpdateUIPrefsAPI extends API {
     }
 
     getPayload() {
-        return this.updateUIPrefs;
+        return this.payload;
     }
 }

--- a/src/Lib/Features/user/UpdateUIPrefs.js
+++ b/src/Lib/Features/user/UpdateUIPrefs.js
@@ -6,13 +6,11 @@ import constants from "@/Constants/constants";
 export default class UpdateUIPrefsAPI extends API {
     /**
      * @param {Object} payload - Any subset of:
-     *   { prefer_cl_ui, instruction_panel_width, annotation_font_size, instruction_panel_pinned }
+     *   { instruction_panel_width, annotation_font_size, instruction_panel_pinned }
      */
     constructor(payload, timeout = 2000) {
         super("POST", timeout, false);
-        this.payload = typeof payload === "boolean"
-            ? { prefer_cl_ui: payload }  // backward-compat: old callers pass a bool directly
-            : payload;
+        this.payload = payload;
         this.type = constants.UPDATE_UI_PREFS;
         this.endpoint = `${super.apiEndPointAuto()}${ENDPOINTS.fetch}update_ui_prefs/`;
     }

--- a/src/Lib/Features/user/UpdateUIPrefs.js
+++ b/src/Lib/Features/user/UpdateUIPrefs.js
@@ -1,16 +1,11 @@
-
+// This file is not used anywhere right now. If needed be can be removed in future as requirements change.
 import API from "@/Constants/api";
 import ENDPOINTS from "../../../config/apiendpoint"
 import constants from "@/Constants/constants";
 
 export default class UpdateUIPrefsAPI extends API {
-    /**
-     * @param {Object} payload - Any subset of:
-     *   { instruction_panel_width, annotation_font_size, instruction_panel_pinned }
-     */
-    constructor(payload, timeout = 2000) {
+    constructor(timeout = 2000) {
         super("POST", timeout, false);
-        this.payload = payload;
         this.type = constants.UPDATE_UI_PREFS;
         this.endpoint = `${super.apiEndPointAuto()}${ENDPOINTS.fetch}update_ui_prefs/`;
     }
@@ -24,7 +19,7 @@ export default class UpdateUIPrefsAPI extends API {
     }
 
     getBody() {
-        return this.payload;
+        return {};
     }
 
     getHeaders() {
@@ -38,6 +33,6 @@ export default class UpdateUIPrefsAPI extends API {
     }
 
     getPayload() {
-        return this.payload;
+        return {};
     }
 }

--- a/src/app/ui/pages/chat/InstructionDrivenChatPage.js
+++ b/src/app/ui/pages/chat/InstructionDrivenChatPage.js
@@ -33,6 +33,11 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CodeIcon from '@mui/icons-material/Code';
 import AssignmentIcon from '@mui/icons-material/Assignment';
+import PushPinIcon from '@mui/icons-material/PushPin';
+import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import Slider from '@mui/material/Slider';
+import UpdateUIPrefsAPI from '@/Lib/Features/user/UpdateUIPrefs';
 const useStyles = makeStyles((theme) => ({
   tooltip: {
     fontSize: "1rem !important",
@@ -102,34 +107,74 @@ const InstructionDrivenChatPage = ({
   const load_time = useRef();
 const [isDragging, setIsDragging] = useState(false);
 const [instructionWidth, setInstructionWidth] = useState(30);
+const [isPinned, setIsPinned] = useState(false);
+const [fontSize, setFontSize] = useState(0.9);
 const containerRef = useRef(null);
 
+const saveAnnotationPref = useCallback(async (payload) => {
+  try {
+    const obj = new UpdateUIPrefsAPI(payload);
+    await fetch(obj.apiEndPoint(), {
+      method: 'POST',
+      body: JSON.stringify(obj.getBody()),
+      headers: obj.getHeaders().headers,
+    });
+  } catch (err) {
+    console.error('Failed to save annotation UI preference', err);
+  }
+}, []);
+
 const startDragging = useCallback((e) => {
+  if (isPinned) return;
   e.preventDefault();
   setIsDragging(true);
-  console.log("Drag");
-  
-}, []);
+}, [isPinned]);
 
 const stopDragging = useCallback(() => {
+  if (!isDragging) return;
   setIsDragging(false);
-}, []);
+  // Persist width when drag ends (only if not pinned — pin locks it after first save)
+  setInstructionWidth((currentWidth) => {
+    saveAnnotationPref({ instruction_panel_width: Math.round(currentWidth * 10) / 10 });
+    return currentWidth;
+  });
+}, [isDragging, saveAnnotationPref]);
 
 const onDrag = useCallback((e) => {
-  console.log("dragg",isDragging);
-  
   if (!isDragging || !containerRef.current) return;
-console.log(e.clientX,"drag");
-
   const containerRect = containerRef.current.getBoundingClientRect();
-  const dragX = e.clientX;
-  const containerLeft = containerRect.left;
-  const containerWidth = containerRect.width;
-  
-  const percentage = ((dragX - containerLeft) / containerWidth) * 100;
-  const newWidth = Math.min(60, Math.max(20, percentage));
+  const percentage = ((e.clientX - containerRect.left) / containerRect.width) * 100;
+  const newWidth = Math.min(60, Math.max(25, percentage));
   setInstructionWidth(newWidth);
 }, [isDragging]);
+
+const handlePinToggle = useCallback(() => {
+  const newPinned = !isPinned;
+  setIsPinned(newPinned);
+  saveAnnotationPref({
+    instruction_panel_pinned: newPinned,
+    instruction_panel_width: Math.round(instructionWidth * 10) / 10,
+  });
+}, [isPinned, instructionWidth, saveAnnotationPref]);
+
+const handleFontSizeChange = useCallback((_e, newVal) => {
+  setFontSize(newVal);
+}, []);
+
+const handleFontSizeCommit = useCallback((_e, newVal) => {
+  saveAnnotationPref({ annotation_font_size: newVal });
+}, [saveAnnotationPref]);
+
+const handleResetUIPrefs = useCallback(() => {
+  setFontSize(0.9);
+  setInstructionWidth(30);
+  setIsPinned(false);
+  saveAnnotationPref({
+    annotation_font_size: 0.9,
+    instruction_panel_width: 30,
+    instruction_panel_pinned: false
+  });
+}, [saveAnnotationPref]);
 
 useEffect(() => {
   if (isDragging) {
@@ -149,6 +194,24 @@ const [snackbar, setSnackbarInfo] = useState({
   const ProjectDetails = useSelector((state) => state.getProjectDetails?.data);
 
   const loggedInUserData = useSelector((state) => state.getLoggedInData?.data);
+
+  // Sync annotation UI preferences from user profile on mount / when user data loads
+  useEffect(() => {
+    if (loggedInUserData?.annotation_ui_preferences) {
+      const prefs = loggedInUserData.annotation_ui_preferences;
+      if (typeof prefs.instruction_panel_width === 'number') {
+        setInstructionWidth(prefs.instruction_panel_width);
+      }
+      if (typeof prefs.annotation_font_size === 'number') {
+        setFontSize(prefs.annotation_font_size);
+      }
+      if (typeof prefs.instruction_panel_pinned === 'boolean') {
+        setIsPinned(prefs.instruction_panel_pinned);
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loggedInUserData?.id]);
+
   const handleOpen = () => {
     setOpen(true);
   };
@@ -541,7 +604,7 @@ const renderChatHistory = () => {
                         {...props}
                         className=""
                         style={{
-                          fontSize: "0.9rem",
+                          fontSize: `${fontSize}rem`,
                           width: "100%",
                           borderRadius: "12px 12px 0 12px",
                           color: grey[900],
@@ -569,7 +632,7 @@ const renderChatHistory = () => {
                       handleTextChange(e, null, message, "prompt")
                     }
                     style={{
-                      fontSize: "0.9rem",
+                      fontSize: `${fontSize}rem`,
                       width: "100%",
                       borderRadius: "12px 12px 0 12px",
                       color: grey[900],
@@ -589,7 +652,7 @@ const renderChatHistory = () => {
                   className="flex-col"
                   children={message?.prompt?.replace(/\n/gi, "&nbsp; \n")}
                   components={{
-                    p: ({node, ...props}) => <p style={{fontSize: '0.9rem', margin: '0.5rem 0'}} {...props} />,
+                    p: ({node, ...props}) => <p style={{fontSize: `${fontSize}rem`, margin: '0.5rem 0'}} {...props} />,
                   }}
                 />
               )}
@@ -690,7 +753,7 @@ const renderChatHistory = () => {
                           }
                           lang={targetLang}
                           style={{
-                            fontSize: "0.9rem",
+                            fontSize: `${fontSize}rem`,
                             borderRadius: "12px 12px 0 12px",
                             color: grey[900],
                             background: "#ffffff",
@@ -713,7 +776,7 @@ const renderChatHistory = () => {
                             handleTextChange(e, index, message, "output")
                           }
                           style={{
-                            fontSize: "0.9rem",
+                            fontSize: `${fontSize}rem`,
                             width: "100%",
                             borderRadius: "12px 12px 0 12px",
                             color: grey[900],
@@ -731,7 +794,7 @@ const renderChatHistory = () => {
                         key={index}
                         children={segment?.value?.replace(/\n/gi, "&nbsp; \n")}
                         components={{
-                          p: ({node, ...props}) => <p style={{fontSize: '0.9rem', margin: '0.5rem 0'}} {...props} />,
+                          p: ({node, ...props}) => <p style={{fontSize: `${fontSize}rem`, margin: '0.5rem 0'}} {...props} />,
                         }}
                       />
                     )
@@ -743,7 +806,7 @@ const renderChatHistory = () => {
                       customStyle={{ 
                         padding: "0.8rem",
                         borderRadius: "5px",
-                        fontSize: "0.9rem"
+                        fontSize: `${fontSize}rem`
                       }}
                     >
                       {segment.value}
@@ -913,12 +976,13 @@ return (
       }
     }}
   />
-)}        <Box
+)}
+        <Box
           sx={{
             display: "flex",
             alignItems: "center",
             justifyContent: isInstructionExpanded ? "space-between" : "center",
-            marginBottom: isInstructionExpanded ? "1rem" : 0,
+            marginBottom: isInstructionExpanded ? "0.5rem" : 0,
             padding: "0.5rem",
             backgroundColor: "rgba(247, 184, 171, 0.2)",
             borderRadius: "8px",
@@ -940,32 +1004,98 @@ return (
               {translate("typography.instructions")}
             </Typography>
           )}
-          <Tooltip
-            title={
-              <span style={{ fontFamily: "Roboto, sans-serif" }}>
-                {isInstructionExpanded ? "Collapse" : "Expand"}
-              </span>
-            }
-          >
-            <IconButton
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                setIsInstructionExpanded(!isInstructionExpanded);
-              }}
-              sx={{ 
-                padding: isInstructionExpanded ? '8px' : '4px',
-                minWidth: 'auto'
-              }}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            {isInstructionExpanded && (
+              <Tooltip
+                title={
+                  <span style={{ fontFamily: "Roboto, sans-serif" }}>
+                      {isPinned ? "Unpin panel width" : "Pin panel width"}
+                    </span>
+                  }
+                >
+                <IconButton
+                  size="small"
+                  onClick={(e) => { e.stopPropagation(); handlePinToggle(); }}
+                  sx={{ padding: "4px", minWidth: "auto" }}
+                >
+                  {isPinned
+                    ? <PushPinIcon style={{ fontSize: "1rem", color: "#EE6633" }} />
+                    : <PushPinOutlinedIcon style={{ fontSize: "1rem", color: "#888" }} />}
+                </IconButton>
+              </Tooltip>
+            )}
+            <Tooltip
+              title={
+                <span style={{ fontFamily: "Roboto, sans-serif" }}>
+                  {isInstructionExpanded ? "Collapse" : "Expand"}
+                </span>
+              }
             >
-              {isInstructionExpanded ? (
-                <ChevronLeftIcon style={{ fontSize: "1.2rem", color: "#EE6633" }} />
-              ) : (
-                <ChevronRightIcon style={{ fontSize: "1.2rem", color: "#EE6633" }} />
-              )}
-            </IconButton>
-          </Tooltip>
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setIsInstructionExpanded(!isInstructionExpanded);
+                }}
+                sx={{ 
+                  padding: isInstructionExpanded ? '8px' : '4px',
+                  minWidth: 'auto'
+                }}
+              >
+                {isInstructionExpanded ? (
+                  <ChevronLeftIcon style={{ fontSize: "1.2rem", color: "#EE6633" }} />
+                ) : (
+                  <ChevronRightIcon style={{ fontSize: "1.2rem", color: "#EE6633" }} />
+                )}
+              </IconButton>
+            </Tooltip>
+          </Box>
         </Box>
+
+        {/* Font size slider — shown when expanded */}
+        {isInstructionExpanded && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              px: "0.5rem",
+              pb: "0.5rem",
+              flexShrink: 0,
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Typography sx={{ fontSize: "0.7rem", color: "#888", whiteSpace: "nowrap" }}>
+              Aa
+            </Typography>
+            <Slider
+              value={fontSize}
+              min={0.7}
+              max={1.4}
+              step={0.05}
+              onChange={handleFontSizeChange}
+              onChangeCommitted={handleFontSizeCommit}
+              size="small"
+              sx={{
+                color: "#EE6633",
+                width: "100%",
+                "& .MuiSlider-thumb": { width: 12, height: 12 },
+              }}
+            />
+            <Typography sx={{ fontSize: "0.7rem", color: "#888", whiteSpace: "nowrap" }}>
+              {Math.round(fontSize * 16)}px
+            </Typography>
+            <Tooltip title={<span style={{ fontFamily: "Roboto, sans-serif" }}>Reset UI layout</span>}>
+              <IconButton
+                size="small"
+                onClick={(e) => { e.stopPropagation(); handleResetUIPrefs(); }}
+                sx={{ padding: "4px", minWidth: "auto", marginLeft: "4px" }}
+              >
+                <RestartAltIcon style={{ fontSize: "1rem", color: "#EE6633" }} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        )}
 
         {isInstructionExpanded && (
           <Box
@@ -987,7 +1117,7 @@ return (
               <Typography
                 paragraph
                 sx={{
-                  fontSize: "0.9rem",
+                  fontSize: `${fontSize}rem`,
                   lineHeight: "1.5",
                   color: "#333",
                 }}
@@ -1012,7 +1142,7 @@ return (
                   sx={{
                     color: "#F18359",
                     fontWeight: "bold",
-                    fontSize: "1rem",
+                    fontSize: `${fontSize + 0.1}rem`,
                     mb: 1,
                   }}
                 >
@@ -1021,7 +1151,7 @@ return (
                 <Typography
                   variant="body2"
                   sx={{
-                    fontSize: "0.85rem",
+                    fontSize: `${Math.max(0.6, fontSize - 0.05)}rem`,
                     lineHeight: "1.4",
                     color: "#555",
                     backgroundColor: "#f8f9fa",
@@ -1040,7 +1170,7 @@ return (
                   sx={{
                     color: "#F18359",
                     fontWeight: "bold",
-                    fontSize: "1rem",
+                    fontSize: `${fontSize + 0.1}rem`,
                     mb: 1,
                   }}
                 >
@@ -1049,7 +1179,7 @@ return (
                 <Typography
                   variant="body2"
                   sx={{
-                    fontSize: "0.85rem",
+                    fontSize: `${Math.max(0.6, fontSize - 0.05)}rem`,
                     lineHeight: "1.4",
                     color: "#555",
                     backgroundColor: "#f8f9fa",
@@ -1068,7 +1198,7 @@ return (
                   sx={{
                     color: "#F18359",
                     fontWeight: "bold",
-                    fontSize: "1rem",
+                    fontSize: `${fontSize + 0.1}rem`,
                     mb: 1,
                   }}
                 >
@@ -1084,7 +1214,7 @@ return (
                   {info.meta_info_language && (
                     <Box sx={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
                       <CodeIcon fontSize="small" color="primary" />
-                      <Typography variant="body2" sx={{ fontSize: "0.8rem", color: "#666" }}>
+                      <Typography variant="body2" sx={{ fontSize: `${Math.max(0.6, fontSize - 0.1)}rem`, color: "#666" }}>
                         Language: {info.meta_info_language}
                       </Typography>
                     </Box>
@@ -1092,7 +1222,7 @@ return (
                   {taskId && (
                     <Box sx={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
                       <AssignmentIcon fontSize="small" color="secondary" />
-                      <Typography variant="body2" sx={{ fontSize: "0.8rem", color: "#666" }}>
+                      <Typography variant="body2" sx={{ fontSize: `${Math.max(0.6, fontSize - 0.1)}rem`, color: "#666" }}>
                         Task ID: {taskId}
                       </Typography>
                     </Box>

--- a/src/app/ui/pages/chat/InstructionDrivenChatPage.js
+++ b/src/app/ui/pages/chat/InstructionDrivenChatPage.js
@@ -37,7 +37,6 @@ import PushPinIcon from '@mui/icons-material/PushPin';
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import Slider from '@mui/material/Slider';
-import UpdateUIPrefsAPI from '@/Lib/Features/user/UpdateUIPrefs';
 const useStyles = makeStyles((theme) => ({
   tooltip: {
     fontSize: "1rem !important",
@@ -111,16 +110,14 @@ const [isPinned, setIsPinned] = useState(false);
 const [fontSize, setFontSize] = useState(0.9);
 const containerRef = useRef(null);
 
-const saveAnnotationPref = useCallback(async (payload) => {
+const saveAnnotationUIPref = useCallback((payload) => {
   try {
-    const obj = new UpdateUIPrefsAPI(payload);
-    await fetch(obj.apiEndPoint(), {
-      method: 'POST',
-      body: JSON.stringify(obj.getBody()),
-      headers: obj.getHeaders().headers,
-    });
+    const localPrefs = localStorage.getItem("annotation_ui_preferences");
+    const currentPrefs = localPrefs ? JSON.parse(localPrefs) : {};
+    const newPrefs = { ...currentPrefs, ...payload };
+    localStorage.setItem("annotation_ui_preferences", JSON.stringify(newPrefs));
   } catch (err) {
-    console.error('Failed to save annotation UI preference', err);
+    console.error('Failed to save local annotation UI preference', err);
   }
 }, []);
 
@@ -135,10 +132,10 @@ const stopDragging = useCallback(() => {
   setIsDragging(false);
   // Persist width when drag ends (only if not pinned — pin locks it after first save)
   setInstructionWidth((currentWidth) => {
-    saveAnnotationPref({ instruction_panel_width: Math.round(currentWidth * 10) / 10 });
+    saveAnnotationUIPref({ instruction_panel_width: Math.round(currentWidth * 10) / 10 });
     return currentWidth;
   });
-}, [isDragging, saveAnnotationPref]);
+}, [isDragging, saveAnnotationUIPref]);
 
 const onDrag = useCallback((e) => {
   if (!isDragging || !containerRef.current) return;
@@ -151,30 +148,30 @@ const onDrag = useCallback((e) => {
 const handlePinToggle = useCallback(() => {
   const newPinned = !isPinned;
   setIsPinned(newPinned);
-  saveAnnotationPref({
+  saveAnnotationUIPref({
     instruction_panel_pinned: newPinned,
     instruction_panel_width: Math.round(instructionWidth * 10) / 10,
   });
-}, [isPinned, instructionWidth, saveAnnotationPref]);
+}, [isPinned, instructionWidth, saveAnnotationUIPref]);
 
 const handleFontSizeChange = useCallback((_e, newVal) => {
   setFontSize(newVal);
 }, []);
 
 const handleFontSizeCommit = useCallback((_e, newVal) => {
-  saveAnnotationPref({ annotation_font_size: newVal });
-}, [saveAnnotationPref]);
+  saveAnnotationUIPref({ annotation_font_size: newVal });
+}, [saveAnnotationUIPref]);
 
 const handleResetUIPrefs = useCallback(() => {
   setFontSize(0.9);
   setInstructionWidth(30);
   setIsPinned(false);
-  saveAnnotationPref({
+  saveAnnotationUIPref({
     annotation_font_size: 0.9,
     instruction_panel_width: 30,
     instruction_panel_pinned: false
   });
-}, [saveAnnotationPref]);
+}, [saveAnnotationUIPref]);
 
 useEffect(() => {
   if (isDragging) {
@@ -195,22 +192,26 @@ const [snackbar, setSnackbarInfo] = useState({
 
   const loggedInUserData = useSelector((state) => state.getLoggedInData?.data);
 
-  // Sync annotation UI preferences from user profile on mount / when user data loads
+  // Sync annotation UI preferences from localStorage on mount
   useEffect(() => {
-    if (loggedInUserData?.annotation_ui_preferences) {
-      const prefs = loggedInUserData.annotation_ui_preferences;
-      if (typeof prefs.instruction_panel_width === 'number') {
-        setInstructionWidth(prefs.instruction_panel_width);
-      }
-      if (typeof prefs.annotation_font_size === 'number') {
-        setFontSize(prefs.annotation_font_size);
-      }
-      if (typeof prefs.instruction_panel_pinned === 'boolean') {
-        setIsPinned(prefs.instruction_panel_pinned);
+    const localPrefs = localStorage.getItem("annotation_ui_preferences");
+    if (localPrefs) {
+      try {
+        const prefs = JSON.parse(localPrefs);
+        if (typeof prefs.instruction_panel_width === 'number') {
+          setInstructionWidth(prefs.instruction_panel_width);
+        }
+        if (typeof prefs.annotation_font_size === 'number') {
+          setFontSize(prefs.annotation_font_size);
+        }
+        if (typeof prefs.instruction_panel_pinned === 'boolean') {
+          setIsPinned(prefs.instruction_panel_pinned);
+        }
+      } catch (err) {
+        console.error('Failed to parse local annotation UI preferences', err);
       }
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loggedInUserData?.id]);
+  }, []);
 
   const handleOpen = () => {
     setOpen(true);

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -45,6 +45,11 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CodeIcon from '@mui/icons-material/Code';
 import AssignmentIcon from '@mui/icons-material/Assignment';
+import PushPinIcon from '@mui/icons-material/PushPin';
+import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import Slider from '@mui/material/Slider';
+import UpdateUIPrefsAPI from '@/Lib/Features/user/UpdateUIPrefs';
 
 const orange = {
   200: "pink",
@@ -131,59 +136,126 @@ const MultipleLLMInstructionDrivenChat = ({
   const [globalTransliteration, setGlobalTransliteration] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-const [instructionWidth, setInstructionWidth] = useState(30); // percentage for desktop
-const containerRef = useRef(null);
+  const [instructionWidth, setInstructionWidth] = useState(30); // percentage for desktop
+  const [isPinned, setIsPinned] = useState(false);
+  const [fontSize, setFontSize] = useState(0.9);
+  const containerRef = useRef(null);
 
-// Add these handler functions inside the component
-const startDragging = useCallback((e) => {
-  e.preventDefault();
-  setIsDragging(true);
-}, []);
+  const saveAnnotationPref = useCallback(async (payload) => {
+    try {
+      const obj = new UpdateUIPrefsAPI(payload);
+      await fetch(obj.apiEndPoint(), {
+        method: 'POST',
+        body: JSON.stringify(obj.getBody()),
+        headers: obj.getHeaders().headers,
+      });
+    } catch (err) {
+      console.error('Failed to save annotation UI preference', err);
+    }
+  }, []);
 
-const stopDragging = useCallback(() => {
-  setIsDragging(false);
-}, []);
+  const startDragging = useCallback((e) => {
+    if (isPinned) return;
+    e.preventDefault();
+    setIsDragging(true);
+  }, [isPinned]);
 
-const onDrag = useCallback((e) => {
-  if (!isDragging || !containerRef.current) return;
+  const stopDragging = useCallback(() => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    // Persist width when drag ends
+    setInstructionWidth((currentWidth) => {
+      saveAnnotationPref({ instruction_panel_width: Math.round(currentWidth * 10) / 10 });
+      return currentWidth;
+    });
+  }, [isDragging, saveAnnotationPref]);
 
-  const containerRect = containerRef.current.getBoundingClientRect();
-  let newWidth;
+  const onDrag = useCallback((e) => {
+    if (!isDragging || !containerRef.current) return;
 
-  if (window.innerWidth < 768) {
-    // For mobile, use percentage of screen height
-    const dragY = e.clientY;
-    const containerTop = containerRect.top;
-    const containerBottom = containerRect.bottom;
-    const containerHeight = containerBottom - containerTop;
-    
-    // Calculate percentage based on Y position (inverted for top panel)
-    const percentage = ((dragY - containerTop) / containerHeight) * 100;
-    newWidth = Math.min(70, Math.max(20, percentage)); // Limit between 20% and 70%
-  } else {
-    // For desktop, use percentage of width
-    const dragX = e.clientX;
-    const containerLeft = containerRect.left;
-    const containerWidth = containerRect.width;
-    
-    // Calculate percentage based on X position
-    const percentage = ((dragX - containerLeft) / containerWidth) * 100;
-    newWidth = Math.min(60, Math.max(20, percentage)); // Limit between 20% and 60%
-  }
+    const containerRect = containerRef.current.getBoundingClientRect();
+    let newWidth;
 
-  setInstructionWidth(newWidth);
-}, [isDragging]);
+    if (window.innerWidth < 768) {
+      // For mobile, use percentage of screen height
+      const dragY = e.clientY;
+      const containerTop = containerRect.top;
+      const containerBottom = containerRect.bottom;
+      const containerHeight = containerBottom - containerTop;
+      
+      // Calculate percentage based on Y position (inverted for top panel)
+      const percentage = ((dragY - containerTop) / containerHeight) * 100;
+      newWidth = Math.min(70, Math.max(25, percentage)); // Limit between 25% and 70%
+    } else {
+      // For desktop, use percentage of width
+      const dragX = e.clientX;
+      const containerLeft = containerRect.left;
+      const containerWidth = containerRect.width;
+      
+      // Calculate percentage based on X position
+      const percentage = ((dragX - containerLeft) / containerWidth) * 100;
+      newWidth = Math.min(60, Math.max(25, percentage)); // Limit between 25% and 60%
+    }
 
-useEffect(() => {
-  if (isDragging) {
-    window.addEventListener('mousemove', onDrag);
-    window.addEventListener('mouseup', stopDragging);
-  }
-  return () => {
-    window.removeEventListener('mousemove', onDrag);
-    window.removeEventListener('mouseup', stopDragging);
-  };
-}, [isDragging, onDrag, stopDragging]);
+    setInstructionWidth(newWidth);
+  }, [isDragging]);
+
+  const handlePinToggle = useCallback(() => {
+    const newPinned = !isPinned;
+    setIsPinned(newPinned);
+    saveAnnotationPref({
+      instruction_panel_pinned: newPinned,
+      instruction_panel_width: Math.round(instructionWidth * 10) / 10,
+    });
+  }, [isPinned, instructionWidth, saveAnnotationPref]);
+
+  const handleFontSizeChange = useCallback((_e, newVal) => {
+    setFontSize(newVal);
+  }, []);
+
+  const handleFontSizeCommit = useCallback((_e, newVal) => {
+    saveAnnotationPref({ annotation_font_size: newVal });
+  }, [saveAnnotationPref]);
+
+  const handleResetUIPrefs = useCallback(() => {
+    setFontSize(0.9);
+    setInstructionWidth(30);
+    setIsPinned(false);
+    saveAnnotationPref({
+      annotation_font_size: 0.9,
+      instruction_panel_width: 30,
+      instruction_panel_pinned: false
+    });
+  }, [saveAnnotationPref]);
+
+  // Sync annotation UI preferences from user profile on mount
+  useEffect(() => {
+    if (loggedInUserData?.annotation_ui_preferences) {
+      const prefs = loggedInUserData.annotation_ui_preferences;
+      if (typeof prefs.instruction_panel_width === 'number') {
+        setInstructionWidth(prefs.instruction_panel_width);
+      }
+      if (typeof prefs.annotation_font_size === 'number') {
+        setFontSize(prefs.annotation_font_size);
+      }
+      if (typeof prefs.instruction_panel_pinned === 'boolean') {
+        setIsPinned(prefs.instruction_panel_pinned);
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loggedInUserData?.id]);
+
+  useEffect(() => {
+    if (isDragging) {
+      window.addEventListener('mousemove', onDrag);
+      window.addEventListener('mouseup', stopDragging);
+    }
+    return () => {
+      window.removeEventListener('mousemove', onDrag);
+      window.removeEventListener('mouseup', stopDragging);
+    };
+  }, [isDragging, onDrag, stopDragging]);
+
   const labels = {
     1: "Poor",
     2: "Fair",
@@ -1429,7 +1501,7 @@ useEffect(() => {
                           {...props}
                           className=""
                           style={{
-                            fontSize: "0.85rem",
+                            fontSize: `${fontSize}rem`,
                             width: "100%",
                             borderRadius: "8px",
                             color: grey[900],
@@ -1458,7 +1530,7 @@ useEffect(() => {
                       value={message.prompt}
                       onChange={(e) => handleTextChange(e.target.value, message, null, null, "prompt")}
                       style={{
-                        fontSize: "0.85rem",
+                        fontSize: `${fontSize}rem`,
                         width: "100%",
                         borderRadius: "8px",
                         color: grey[900],
@@ -1498,7 +1570,7 @@ useEffect(() => {
                       className="flex-col"
                       children={message?.prompt?.replace(/\\n/gi, "&nbsp; \\n")}
                       components={{
-                        p: ({ node, ...props }) => <p style={{ fontSize: '0.85rem', margin: '0.3rem 0', lineHeight: '1.3' }} {...props} />,
+                        p: ({ node, ...props }) => <p style={{ fontSize: `${fontSize}rem`, margin: '0.3rem 0', lineHeight: '1.3' }} {...props} />,
                       }}
                     />
                   </div>
@@ -1737,7 +1809,7 @@ useEffect(() => {
                                                   <textarea
                                                     {...props}
                                                     style={{
-                                                      fontSize: "0.8rem",
+                                                      fontSize: `${fontSize}rem`,
                                                       padding: "6px",
                                                       borderRadius: "6px",
                                                       color: grey[900],
@@ -1757,7 +1829,7 @@ useEffect(() => {
                                                 value={segment.value}
                                                 onChange={(e) => handleTextChange(e.target.value, message, modelIdx, segmentIdx, "output")}
                                                 style={{
-                                                  fontSize: "0.8rem",
+                                                  fontSize: `${fontSize}rem`,
                                                   width: "100%",
                                                   padding: "6px",
                                                   borderRadius: "6px",
@@ -1784,7 +1856,7 @@ useEffect(() => {
                                                 key={segmentIdx}
                                                 children={segment?.value?.replace(/\\n/gi, "&nbsp; \\n")}
                                                 components={{
-                                                  p: ({ node, ...props }) => <p style={{ fontSize: '0.8rem', margin: '0.2rem 0', lineHeight: '1.2' }} {...props} />,
+                                                  p: ({ node, ...props }) => <p style={{ fontSize: `${fontSize}rem`, margin: '0.2rem 0', lineHeight: '1.2' }} {...props} />,
                                                 }}
                                               />
                                             </div>
@@ -1797,7 +1869,7 @@ useEffect(() => {
                                             customStyle={{
                                               padding: "0.5rem",
                                               borderRadius: "4px",
-                                              fontSize: "0.8rem",
+                                              fontSize: `${fontSize}rem`,
                                               margin: "0.2rem 0"
                                             }}
                                           >
@@ -1833,7 +1905,7 @@ useEffect(() => {
                                           <textarea
                                             {...props}
                                             style={{
-                                              fontSize: "0.8rem",
+                                              fontSize: `${fontSize}rem`,
                                               padding: "6px",
                                               borderRadius: "6px",
                                               color: grey[900],
@@ -1853,7 +1925,7 @@ useEffect(() => {
                                         value={segment.value}
                                         onChange={(e) => handleTextChange(e.target.value, message, modelIdx, segmentIdx, "output")}
                                         style={{
-                                          fontSize: "0.8rem",
+                                          fontSize: `${fontSize}rem`,
                                           width: "100%",
                                           padding: "6px",
                                           borderRadius: "6px",
@@ -1872,7 +1944,7 @@ useEffect(() => {
                                       key={segmentIdx}
                                       children={segment?.value?.replace(/\\n/gi, "&nbsp; \\n")}
                                       components={{
-                                        p: ({node, ...props}) => <p style={{fontSize: '0.8rem', margin: '0.2rem 0', lineHeight: '1.2'}} {...props} />,
+                                        p: ({node, ...props}) => <p style={{fontSize: `${fontSize}rem`, margin: '0.2rem 0', lineHeight: '1.2'}} {...props} />,
                                       }}
                                     />
                                   )
@@ -1884,7 +1956,7 @@ useEffect(() => {
                                     customStyle={{ 
                                       padding: "0.5rem", 
                                       borderRadius: "4px", 
-                                      fontSize: "0.8rem",
+                                      fontSize: `${fontSize}rem`,
                                       margin: "0.2rem 0" 
                                     }}
                                   >
@@ -2857,7 +2929,7 @@ useEffect(() => {
                         maxWidth: "fit-content",
                         marginBottom: "16px",
                         marginRight: "16px",
-                        fontSize: "0.8rem",
+                        fontSize: `${fontSize}rem`,
                         minHeight: "auto",
                       }}
                       onClick={() => {
@@ -3029,7 +3101,7 @@ return (
             display: "flex",
             alignItems: "center",
             justifyContent: isInstructionExpanded ? "space-between" : "center",
-            marginBottom: isInstructionExpanded ? "1rem" : 0,
+            marginBottom: isInstructionExpanded ? "0.5rem" : 0,
             padding: "0.5rem",
             backgroundColor: "rgba(247, 184, 171, 0.2)",
             borderRadius: "8px",
@@ -3051,31 +3123,98 @@ return (
               {translate("typography.instructions")}
             </Typography>
           )}
-          <Tooltip
-            title={<span style={{ fontFamily: "Roboto, sans-serif" }}>{isInstructionExpanded ? "Collapse" : "Expand"}</span>}
-          >
-            <IconButton
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                setIsInstructionExpanded(!isInstructionExpanded);
-              }}
-              sx={{ padding: isInstructionExpanded ? '8px' : '4px', minWidth: 'auto' }}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            {isInstructionExpanded && (
+              <Tooltip
+                title={
+                  <span style={{ fontFamily: "Roboto, sans-serif" }}>
+                      {isPinned ? "Unpin panel width" : "Pin panel width"}
+                    </span>
+                  }
+                >
+                  <IconButton
+                    size="small"
+                    onClick={(e) => { e.stopPropagation(); handlePinToggle(); }}
+                    sx={{ padding: "4px", minWidth: "auto" }}
+                  >
+                    {isPinned
+                      ? <PushPinIcon style={{ fontSize: "1rem", color: "#EE6633" }} />
+                      : <PushPinOutlinedIcon style={{ fontSize: "1rem", color: "#888" }} />}
+                  </IconButton>
+                </Tooltip>
+            )}
+            <Tooltip
+              title={<span style={{ fontFamily: "Roboto, sans-serif" }}>{isInstructionExpanded ? "Collapse" : "Expand"}</span>}
             >
-              {isInstructionExpanded ? (
-                <ChevronLeftIcon style={{ fontSize: "1.2rem", color: "#EE6633" }} />
-              ) : (
-                <ChevronRightIcon style={{ fontSize: "1.2rem", color: "#EE6633" }} />
-              )}
-            </IconButton>
-          </Tooltip>
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setIsInstructionExpanded(!isInstructionExpanded);
+                }}
+                sx={{ padding: isInstructionExpanded ? '8px' : '4px', minWidth: 'auto' }}
+              >
+                {isInstructionExpanded ? (
+                  <ChevronLeftIcon style={{ fontSize: "1.2rem", color: "#EE6633" }} />
+                ) : (
+                  <ChevronRightIcon style={{ fontSize: "1.2rem", color: "#EE6633" }} />
+                )}
+              </IconButton>
+            </Tooltip>
+          </Box>
         </Box>
+
+        {/* Font size slider — shown when expanded */}
+        {isInstructionExpanded && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              px: "0.5rem",
+              pb: "0.5rem",
+              flexShrink: 0,
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Typography sx={{ fontSize: "0.7rem", color: "#888", whiteSpace: "nowrap" }}>
+              Aa
+            </Typography>
+            <Slider
+              value={fontSize}
+              min={0.7}
+              max={1.4}
+              step={0.05}
+              onChange={handleFontSizeChange}
+              onChangeCommitted={handleFontSizeCommit}
+              size="small"
+              sx={{
+                color: "#EE6633",
+                width: "100%",
+                "& .MuiSlider-thumb": { width: 12, height: 12 },
+              }}
+            />
+            <Typography sx={{ fontSize: "0.7rem", color: "#888", whiteSpace: "nowrap" }}>
+              {Math.round(fontSize * 16)}px
+            </Typography>
+            <Tooltip title={<span style={{ fontFamily: "Roboto, sans-serif" }}>Reset UI layout</span>}>
+              <IconButton
+                size="small"
+                onClick={(e) => { e.stopPropagation(); handleResetUIPrefs(); }}
+                sx={{ padding: "4px", minWidth: "auto", marginLeft: "4px" }}
+              >
+                <RestartAltIcon style={{ fontSize: "1rem", color: "#EE6633" }} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        )}
+
 
         {isInstructionExpanded && (
           <Box sx={{ flex: 1, overflow: "auto", padding: "0.5rem" }}>
             {/* Main Instructions */}
             <Box sx={{ backgroundColor: "white", borderRadius: "8px", padding: "1rem", boxShadow: "0 2px 4px rgba(0,0,0,0.1)", marginBottom: "1rem" }}>
-              <Typography paragraph sx={{ fontSize: "0.9rem", lineHeight: "1.5", color: "#333" }}>
+              <Typography paragraph sx={{ fontSize: `${fontSize}rem`, lineHeight: "1.5", color: "#333" }}>
                 {info.instruction_data}
               </Typography>
             </Box>
@@ -3088,7 +3227,7 @@ return (
                   sx={{
                     color: "#F18359",
                     fontWeight: "bold",
-                    fontSize: "1rem",
+                    fontSize: `${fontSize + 0.1}rem`,
                     mb: 1,
                   }}
                 >
@@ -3097,7 +3236,7 @@ return (
                 <Typography
                   variant="body2"
                   sx={{
-                    fontSize: "0.85rem",
+                    fontSize: `${Math.max(0.6, fontSize - 0.05)}rem`,
                     lineHeight: "1.4",
                     color: "#555",
                     backgroundColor: "#f8f9fa",
@@ -3116,7 +3255,7 @@ return (
                   sx={{
                     color: "#F18359",
                     fontWeight: "bold",
-                    fontSize: "1rem",
+                    fontSize: `${fontSize + 0.1}rem`,
                     mb: 1,
                   }}
                 >
@@ -3125,7 +3264,7 @@ return (
                 <Typography
                   variant="body2"
                   sx={{
-                    fontSize: "0.85rem",
+                    fontSize: `${Math.max(0.6, fontSize - 0.05)}rem`,
                     lineHeight: "1.4",
                     color: "#555",
                     backgroundColor: "#f8f9fa",
@@ -3144,7 +3283,7 @@ return (
                   sx={{
                     color: "#F18359",
                     fontWeight: "bold",
-                    fontSize: "1rem",
+                    fontSize: `${fontSize + 0.1}rem`,
                     mb: 1,
                   }}
                 >
@@ -3160,7 +3299,7 @@ return (
                   {info.meta_info_language && (
                     <Box sx={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
                       <CodeIcon fontSize="small" color="primary" />
-                      <Typography variant="body2" sx={{ fontSize: "0.8rem", color: "#666" }}>
+                      <Typography variant="body2" sx={{ fontSize: `${Math.max(0.6, fontSize - 0.1)}rem`, color: "#666" }}>
                         Language: {info.meta_info_language}
                       </Typography>
                     </Box>
@@ -3168,7 +3307,7 @@ return (
                   {taskId && (
                     <Box sx={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
                       <AssignmentIcon fontSize="small" color="secondary" />
-                      <Typography variant="body2" sx={{ fontSize: "0.8rem", color: "#666" }}>
+                      <Typography variant="body2" sx={{ fontSize: `${Math.max(0.6, fontSize - 0.1)}rem`, color: "#666" }}>
                         Task ID: {taskId}
                       </Typography>
                     </Box>

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -49,7 +49,6 @@ import PushPinIcon from '@mui/icons-material/PushPin';
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import Slider from '@mui/material/Slider';
-import UpdateUIPrefsAPI from '@/Lib/Features/user/UpdateUIPrefs';
 
 const orange = {
   200: "pink",
@@ -141,16 +140,14 @@ const MultipleLLMInstructionDrivenChat = ({
   const [fontSize, setFontSize] = useState(0.9);
   const containerRef = useRef(null);
 
-  const saveAnnotationPref = useCallback(async (payload) => {
+  const saveAnnotationUIPref = useCallback((payload) => {
     try {
-      const obj = new UpdateUIPrefsAPI(payload);
-      await fetch(obj.apiEndPoint(), {
-        method: 'POST',
-        body: JSON.stringify(obj.getBody()),
-        headers: obj.getHeaders().headers,
-      });
+      const localPrefs = localStorage.getItem("annotation_ui_preferences");
+      const currentPrefs = localPrefs ? JSON.parse(localPrefs) : {};
+      const newPrefs = { ...currentPrefs, ...payload };
+      localStorage.setItem("annotation_ui_preferences", JSON.stringify(newPrefs));
     } catch (err) {
-      console.error('Failed to save annotation UI preference', err);
+      console.error('Failed to save local annotation UI preference', err);
     }
   }, []);
 
@@ -165,10 +162,10 @@ const MultipleLLMInstructionDrivenChat = ({
     setIsDragging(false);
     // Persist width when drag ends
     setInstructionWidth((currentWidth) => {
-      saveAnnotationPref({ instruction_panel_width: Math.round(currentWidth * 10) / 10 });
+      saveAnnotationUIPref({ instruction_panel_width: Math.round(currentWidth * 10) / 10 });
       return currentWidth;
     });
-  }, [isDragging, saveAnnotationPref]);
+  }, [isDragging, saveAnnotationUIPref]);
 
   const onDrag = useCallback((e) => {
     if (!isDragging || !containerRef.current) return;
@@ -203,47 +200,51 @@ const MultipleLLMInstructionDrivenChat = ({
   const handlePinToggle = useCallback(() => {
     const newPinned = !isPinned;
     setIsPinned(newPinned);
-    saveAnnotationPref({
+    saveAnnotationUIPref({
       instruction_panel_pinned: newPinned,
       instruction_panel_width: Math.round(instructionWidth * 10) / 10,
     });
-  }, [isPinned, instructionWidth, saveAnnotationPref]);
+  }, [isPinned, instructionWidth, saveAnnotationUIPref]);
 
   const handleFontSizeChange = useCallback((_e, newVal) => {
     setFontSize(newVal);
   }, []);
 
   const handleFontSizeCommit = useCallback((_e, newVal) => {
-    saveAnnotationPref({ annotation_font_size: newVal });
-  }, [saveAnnotationPref]);
+    saveAnnotationUIPref({ annotation_font_size: newVal });
+  }, [saveAnnotationUIPref]);
 
   const handleResetUIPrefs = useCallback(() => {
     setFontSize(0.9);
     setInstructionWidth(30);
     setIsPinned(false);
-    saveAnnotationPref({
+    saveAnnotationUIPref({
       annotation_font_size: 0.9,
       instruction_panel_width: 30,
       instruction_panel_pinned: false
     });
-  }, [saveAnnotationPref]);
+  }, [saveAnnotationUIPref]);
 
-  // Sync annotation UI preferences from user profile on mount
+  // Sync annotation UI preferences from localStorage on mount
   useEffect(() => {
-    if (loggedInUserData?.annotation_ui_preferences) {
-      const prefs = loggedInUserData.annotation_ui_preferences;
-      if (typeof prefs.instruction_panel_width === 'number') {
-        setInstructionWidth(prefs.instruction_panel_width);
-      }
-      if (typeof prefs.annotation_font_size === 'number') {
-        setFontSize(prefs.annotation_font_size);
-      }
-      if (typeof prefs.instruction_panel_pinned === 'boolean') {
-        setIsPinned(prefs.instruction_panel_pinned);
+    const localPrefs = localStorage.getItem("annotation_ui_preferences");
+    if (localPrefs) {
+      try {
+        const prefs = JSON.parse(localPrefs);
+        if (typeof prefs.instruction_panel_width === 'number') {
+          setInstructionWidth(prefs.instruction_panel_width);
+        }
+        if (typeof prefs.annotation_font_size === 'number') {
+          setFontSize(prefs.annotation_font_size);
+        }
+        if (typeof prefs.instruction_panel_pinned === 'boolean') {
+          setIsPinned(prefs.instruction_panel_pinned);
+        }
+      } catch (err) {
+        console.error('Failed to parse local annotation UI preferences', err);
       }
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loggedInUserData?.id]);
+  }, []);
 
   useEffect(() => {
     if (isDragging) {

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -191,11 +191,6 @@ const translationServices = {
     getLoggedInUserData();
   }, []);
 
-  /* useEffect(()=>{
-    if(loggedInUserData?.prefer_cl_ui !== undefined){
-      setCheckClUI(loggedInUserData?.prefer_cl_ui)
-    }
-  },[loggedInUserData]) */
 
   // const settings = ['Profile', 'Account', 'Dashboard', 'Logout'];
   const onLogoutClick = () => {

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -18,7 +18,6 @@ import Image from "next/image";
 import Transliteration from "../Transliteration/Transliteration";
 import CustomizedSnackbars from "../common/Snackbar";
 import userRole from "@/utils/UserMappedByRole/Roles";
-import UpdateUIPrefsAPI from "@/Lib/Features/user/UpdateUIPrefs";
 import { FetchLoggedInUserData } from "@/Lib/Features/getLoggedInData";
 import { Link, NavLink } from "react-router-dom";
 import ForgotPasswordAPI from "@/app/actions/api/user/ForgotPasswordAPI";
@@ -297,24 +296,24 @@ useEffect(() => {
     }
   };
 
-  const handleTranscriptionFlowChange = async (event) => {
-    const obj = new UpdateUIPrefsAPI(event.target.checked);
-    // dispatch(APITransport(loggedInUserObj));
-    const res = await fetch(obj.apiEndPoint(), {
-      method: "POST",
-      body: JSON.stringify(obj.getBody()),
-      headers: obj.getHeaders().headers,
-    });
-    const resp = await res.json();
-    if (res.ok) {
-      getLoggedInUserData();
-      setSnackbarInfo({
-        open: true,
-        message: resp.message,
-        variant: "success",
-      });
-    }
-  };
+  // const handleTranscriptionFlowChange = async (event) => {
+  //   const obj = new UpdateUIPrefsAPI(event.target.checked);
+  //   // dispatch(APITransport(loggedInUserObj));
+  //   const res = await fetch(obj.apiEndPoint(), {
+  //     method: "POST",
+  //     body: JSON.stringify(obj.getBody()),
+  //     headers: obj.getHeaders().headers,
+  //   });
+  //   const resp = await res.json();
+  //   if (res.ok) {
+  //     getLoggedInUserData();
+  //     setSnackbarInfo({
+  //       open: true,
+  //       message: resp.message,
+  //       variant: "success",
+  //     });
+  //   }
+  // };
   const handleTabChange = async (index) => {
     if (index === 0) {
       await setunread(null);


### PR DESCRIPTION
Added UI customization options to persist Instruction Panel width and annotation page font size preferences, with localStorage support for saving user preferences.
Added a Reset button to restore default UI customization settings.


updated:-
API Cleanup: Removed the obsolete prefer_cl_ui boolean payload in the UpdateUIPrefsAPI class.
Component Cleanup: Cleared out dead prefer_cl_ui state-checking logic from the global Header.jsx.