### PR TITLE
Refactor notes handling to use state instead of refs

### DIFF
--- a/src/app/ui/pages/chat/AnnotatePage.jsx
+++ b/src/app/ui/pages/chat/AnnotatePage.jsx
@@ -102,10 +102,15 @@ const AnnotatePage = () => {
   const [annotations, setAnnotations] = useState([]);
 
   const annotationNotesRef = useRef(null);
+  const reviewNotesRef = useRef(null);
+
+  // ── useState replacements for the .value workaround on the refs ──
+  const [annotationNotesValue, setAnnotationNotesValue] = useState("");
+  const [reviewNotesValue, setReviewNotesValue] = useState("");
+
   const [loading, setLoading] = useState(false);
   const [disableButton, setDisableButton] = useState(false);
 
-  const reviewNotesRef = useRef(null);
   const [disableBtns, setDisableBtns] = useState(false);
   const [disableUpdateButton, setDisableUpdateButton] = useState(false);
   const [taskDataArr, setTaskDataArr] = useState();
@@ -144,56 +149,74 @@ const AnnotatePage = () => {
     }
   }, [taskData]);
 
+  // Helper: load notes values into Quill editors from state
+  const loadNotesIntoEditors = (annoValue, reviewValue) => {
+    // annotation notes
+    try {
+      const newDelta2 = annoValue !== "" ? JSON.parse(annoValue) : "";
+      annotationNotesRef.current.getEditor().setContents(newDelta2);
+    } catch (err) {
+      if (err) {
+        annotationNotesRef.current.getEditor().setText(annoValue);
+      }
+    }
+
+    // review notes
+    try {
+      const newDelta1 = reviewValue !== "" ? JSON.parse(reviewValue) : "";
+      reviewNotesRef.current.getEditor().setContents(newDelta1);
+    } catch (err) {
+      if (err) {
+        reviewNotesRef.current.getEditor().setText(reviewValue);
+      }
+    }
+
+    setannotationtext(annotationNotesRef.current.getEditor().getText());
+    setreviewtext(reviewNotesRef.current.getEditor().getText());
+  };
+
+  // First useEffect: sync state values when AnnotationsTaskDetails changes
   useEffect(() => {
-    if (
-      typeof window !== "undefined" &&
-      annotationNotesRef.current &&
-      reviewNotesRef.current
-    ) {
+    if (AnnotationsTaskDetails && AnnotationsTaskDetails.length > 0) {
+      const annoValue = AnnotationsTaskDetails[0].annotation_notes ?? "";
+      const reviewValue = AnnotationsTaskDetails[0].review_notes ?? "";
+      setAnnotationNotesValue(annoValue);
+      setReviewNotesValue(reviewValue);
+    }
+  }, [AnnotationsTaskDetails]);
+
+  // Second useEffect: load into Quill editors once refs are ready (polling fallback)
+  useEffect(() => {
+    let timeoutId;
+
+    const init = () => {
       if (
         AnnotationsTaskDetails &&
         AnnotationsTaskDetails.length > 0 &&
-        reviewNotesRef.current &&
-        reviewNotesRef.current.getEditor &&
-        reviewNotesRef.current.getEditor() &&
         annotationNotesRef.current &&
         annotationNotesRef.current.getEditor &&
-        annotationNotesRef.current.getEditor()
+        annotationNotesRef.current.getEditor() &&
+        reviewNotesRef.current &&
+        reviewNotesRef.current.getEditor &&
+        reviewNotesRef.current.getEditor()
       ) {
-        annotationNotesRef.current.value =
-          AnnotationsTaskDetails[0].annotation_notes ?? "";
-        reviewNotesRef.current.value =
-          AnnotationsTaskDetails[0].review_notes ?? "";
-        try {
-          const newDelta2 =
-            annotationNotesRef.current.value !== ""
-              ? JSON.parse(annotationNotesRef.current.value)
-              : "";
-          annotationNotesRef.current.getEditor().setContents(newDelta2);
-        } catch (err) {
-          if (err) {
-            const newDelta2 = annotationNotesRef.current.value;
-            annotationNotesRef.current.getEditor().setText(newDelta2);
-          }
-        }
-
-        try {
-          const newDelta1 =
-            reviewNotesRef.current.value != ""
-              ? JSON.parse(reviewNotesRef.current.value)
-              : "";
-          reviewNotesRef.current.getEditor().setContents(newDelta1);
-        } catch (err) {
-          if (err) {
-            const newDelta1 = reviewNotesRef.current.value;
-            reviewNotesRef.current.getEditor().setText(newDelta1);
-          }
-        }
-        setannotationtext(annotationNotesRef.current.getEditor().getText());
-        setreviewtext(reviewNotesRef.current.getEditor().getText());
+        loadNotesIntoEditors(annotationNotesValue, reviewNotesValue);
       }
-    }
-  }, [AnnotationsTaskDetails]);
+    };
+
+    const check = () => {
+      if (annotationNotesRef.current && reviewNotesRef.current) {
+        init();
+        clearTimeout(timeoutId);
+        return;
+      }
+      timeoutId = setTimeout(check, 100);
+    };
+
+    check();
+
+    return () => clearTimeout(timeoutId);
+  }, [AnnotationsTaskDetails, annotationNotesValue, reviewNotesValue]);
 
   useEffect(() => {
     resetNotes();
@@ -319,91 +342,11 @@ const AnnotatePage = () => {
     return markdownString;
   };
 
-  useEffect(() => {
-    if (taskData) {
-      setInfo((prev) => {
-        return {
-          hint: taskData?.data?.hint,
-          examples: taskData?.data?.examples,
-          meta_info_intent: taskData?.data?.meta_info_intent,
-          instruction_data: taskData?.data?.instruction_data,
-          meta_info_domain: taskData?.data?.meta_info_domain,
-          meta_info_language: taskData?.data?.meta_info_language,
-        };
-      });
-    }
-  }, [taskData]);
- 
-
-  useEffect(() => {
-    let timeoutId;
-
-    const init = (annotationNotesRef,reviewNotesRef) => {
-      if (
-        AnnotationsTaskDetails &&
-        AnnotationsTaskDetails.length > 0 &&
-        reviewNotesRef.current &&
-        reviewNotesRef.current.getEditor &&
-        reviewNotesRef.current.getEditor() &&
-        annotationNotesRef.current &&
-        annotationNotesRef.current.getEditor &&
-        annotationNotesRef.current.getEditor()
-      ) {
-        
-        annotationNotesRef.current.value =
-          AnnotationsTaskDetails[0].annotation_notes ?? "";
-        reviewNotesRef.current.value =
-          AnnotationsTaskDetails[0].review_notes ?? "";
-        try {
-          const newDelta2 =
-            annotationNotesRef.current.value !== ""
-              ? JSON.parse(annotationNotesRef.current.value)
-              : "";
-          annotationNotesRef.current.getEditor().setContents(newDelta2);
-        } catch (err) {
-          if (err) {
-            const newDelta2 = annotationNotesRef.current.value;
-            annotationNotesRef.current.getEditor().setText(newDelta2);
-          }
-        }
-
-        try {
-          const newDelta1 =
-            reviewNotesRef.current.value != ""
-              ? JSON.parse(reviewNotesRef.current.value)
-              : "";
-          reviewNotesRef.current.getEditor().setContents(newDelta1);
-        } catch (err) {
-          if (err) {
-            const newDelta1 = reviewNotesRef.current.value;
-            reviewNotesRef.current.getEditor().setText(newDelta1);
-          }
-        }
-        setannotationtext(annotationNotesRef.current.getEditor().getText());
-        setreviewtext(reviewNotesRef.current.getEditor().getText());
-      }
-    }
-    const check = () => {
-      if (annotationNotesRef.current&&reviewNotesRef.current) {
-        init(annotationNotesRef,reviewNotesRef);
-        clearTimeout(timeoutId); 
-
-        return;
-      }
-      timeoutId = setTimeout(check, 100);
-    };
-    
-
-    check();
-
-  }, [AnnotationsTaskDetails,annotationNotesRef,reviewNotesRef]);
-
   const resetNotes = () => {
-    if (
-      annotationNotesRef.current &&
-      reviewNotesRef.current
-    ) {
-      setShowNotes(false);
+    setAnnotationNotesValue("");
+    setReviewNotesValue("");
+    setShowNotes(false);
+    if (annotationNotesRef.current && reviewNotesRef.current) {
       annotationNotesRef.current.getEditor().setContents([]);
       reviewNotesRef.current.getEditor().setContents([]);
     }
@@ -537,7 +480,7 @@ const AnnotatePage = () => {
       !areAllFormsAnswered()
     ) {      
       console.log(areAllFormsAnswered);
-      
+
       setSnackbarInfo({
         open: true,
         message:
@@ -615,6 +558,15 @@ const AnnotatePage = () => {
     }
     setLoading(true);
     setAutoSave(false);
+
+    // Use the live editor contents for annotation_notes (most up-to-date)
+    const liveAnnotationNotes =
+      typeof window !== "undefined"
+        ? JSON.stringify(
+            annotationNotesRef?.current?.getEditor().getContents(),
+          )
+        : null;
+
     const PatchAPIdata = {
       annotation_status:
         value === "delete" || value === "delete-pair"
@@ -622,12 +574,7 @@ const AnnotatePage = () => {
             ? localStorage.getItem("labellingMode")
             : null
           : value,
-      annotation_notes:
-        typeof window !== "undefined"
-          ? JSON.stringify(
-              annotationNotesRef?.current?.getEditor().getContents(),
-            )
-          : null,
+      annotation_notes: liveAnnotationNotes,
       lead_time:
         (new Date() - loadtime) / 1000 + Number(lead_time?.lead_time ?? 0),
       result: buildResult(value, type, resultValue),
@@ -686,8 +633,13 @@ const AnnotatePage = () => {
       ) {
         if (type === "MultipleLLMInstructionDrivenChat") {
           const allModelsInteractions = resp?.result?.[0]?.model_interactions;
-          if (allModelsInteractions && Array.isArray(allModelsInteractions) && allModelsInteractions.length > 0) {
-            const interactions_length = allModelsInteractions[0]?.interaction_json?.length || 0;
+          if (
+            allModelsInteractions &&
+            Array.isArray(allModelsInteractions) &&
+            allModelsInteractions.length > 0
+          ) {
+            const interactions_length =
+              allModelsInteractions[0]?.interaction_json?.length || 0;
             let modifiedChatHistory = [];
             let globalModelFailure = false;
 
@@ -870,7 +822,6 @@ const AnnotatePage = () => {
           filteredAnnotations = [superCheckedAnnotation];
 
           Message = "This is the Super Checker's Annotation in read only mode";
-
           disableDraft = true;
           disableSkip = true;
           disableUpdate = true;
@@ -907,7 +858,6 @@ const AnnotatePage = () => {
       ) {
         filteredAnnotations = [userAnnotation];
         disableSkip = true;
-
         Message = "Skip button is disabled, since the task is being reviewed";
       } else if (
         userAnnotation &&
@@ -1368,7 +1318,13 @@ const AnnotatePage = () => {
               formats={formats}
               bounds={"#note"}
               placeholder="Annotation Notes"
-            ></ReactQuill>
+              onChange={(_content, _delta, _source, editor) => {
+                setAnnotationNotesValue(
+                  JSON.stringify(editor.getContents()),
+                );
+                setannotationtext(editor.getText());
+              }}
+            />
             <ReactQuill
               forwardedRef={reviewNotesRef}
               modules={modules}
@@ -1377,7 +1333,7 @@ const AnnotatePage = () => {
               placeholder="Review Notes"
               style={{ marginBottom: "8px", minHeight: "2rem" }}
               readOnly={true}
-            ></ReactQuill>
+            />
           </div>
         </Grid>
 

--- a/src/app/ui/pages/chat/ReviewPage.jsx
+++ b/src/app/ui/pages/chat/ReviewPage.jsx
@@ -165,6 +165,11 @@ const ReviewPage = () => {
   const [submittedEvalForms, setSubmittedEvalForms] = useState();
   const [isModelFailing, setIsModelFailing] = useState(false);
 
+  // ── useState replacements for the .value workaround on the refs ──
+  const [annotationNotesValue, setAnnotationNotesValue] = useState("");
+  const [reviewNotesValue, setReviewNotesValue] = useState("");
+  const [superCheckerNotesValue, setSuperCheckerNotesValue] = useState("");
+
   if (typeof window !== "undefined") {
     window.localStorage.setItem("TaskData", JSON.stringify(taskData));
   }
@@ -300,6 +305,18 @@ const ReviewPage = () => {
     return markdownString;
   };
 
+  // Helper: load a single set of note values into their Quill editors
+  const loadIntoEditor = (ref, value) => {
+    try {
+      const delta = value !== "" ? JSON.parse(value) : "";
+      ref.current.getEditor().setContents(delta);
+    } catch (err) {
+      if (err) {
+        ref.current.getEditor().setText(value);
+      }
+    }
+  };
+
   const setNotes = (taskData, annotations) => {
     if (
       typeof window !== "undefined" &&
@@ -320,53 +337,22 @@ const ReviewPage = () => {
           let superCheckerAnnotation = annotations.find(
             (annotation) => annotation.parent_annotation === userAnnotation.id,
           );
-          annotationNotesRef.current.value =
-            normalAnnotation?.annotation_notes ?? "";
-          reviewNotesRef.current.value = userAnnotation?.review_notes ?? "";
-          superCheckerNotesRef.current.value =
-            superCheckerAnnotation?.supercheck_notes ?? "";
-          try {
-            const newDelta2 =
-              annotationNotesRef.current.value !== ""
-                ? JSON.parse(annotationNotesRef.current.value)
-                : "";
-            annotationNotesRef.current.getEditor().setContents(newDelta2);
-          } catch (err) {
-            if (err) {
-              const newDelta2 = annotationNotesRef.current.value;
-              annotationNotesRef.current.getEditor().setText(newDelta2);
-            }
-          }
 
-          try {
-            const newDelta1 =
-              reviewNotesRef.current.value != ""
-                ? JSON.parse(reviewNotesRef.current.value)
-                : "";
-            reviewNotesRef.current.getEditor().setContents(newDelta1);
-          } catch (err) {
-            if (err) {
-              const newDelta1 = reviewNotesRef.current.value;
-              reviewNotesRef.current.getEditor().setText(newDelta1);
-            }
-          }
-          try {
-            const newDelta3 =
-              superCheckerNotesRef.current.value != ""
-                ? JSON.parse(superCheckerNotesRef.current.value)
-                : "";
-            superCheckerNotesRef.current.getEditor().setContents(newDelta3);
-          } catch (err) {
-            if (err) {
-              const newDelta3 = superCheckerNotesRef.current.value;
-              superCheckerNotesRef.current.getEditor().setText(newDelta3);
-            }
-          }
+          const annoVal = normalAnnotation?.annotation_notes ?? "";
+          const reviewVal = userAnnotation?.review_notes ?? "";
+          const superVal = superCheckerAnnotation?.supercheck_notes ?? "";
+
+          setAnnotationNotesValue(annoVal);
+          setReviewNotesValue(reviewVal);
+          setSuperCheckerNotesValue(superVal);
+
+          loadIntoEditor(annotationNotesRef, annoVal);
+          loadIntoEditor(reviewNotesRef, reviewVal);
+          loadIntoEditor(superCheckerNotesRef, superVal);
+
           setannotationtext(annotationNotesRef.current.getEditor().getText());
           setreviewtext(reviewNotesRef.current.getEditor().getText());
-          setsupercheckertext(
-            superCheckerNotesRef.current.getEditor().getText(),
-          );
+          setsupercheckertext(superCheckerNotesRef.current.getEditor().getText());
         } else {
           let reviewerAnnotations = annotations.filter(
             (annotation) => annotation.annotation_type === 2,
@@ -376,172 +362,74 @@ const ReviewPage = () => {
               (annotation) => annotation.id === taskData.correct_annotation,
             );
             if (correctAnnotation) {
-              reviewNotesRef.current.value =
-                correctAnnotation.review_notes ?? "";
-              annotationNotesRef.current.value =
+              const reviewVal = correctAnnotation.review_notes ?? "";
+              const annoVal =
                 annotations.find(
                   (annotation) =>
                     annotation.id === correctAnnotation.parent_annotation,
                 )?.annotation_notes ?? "";
-              superCheckerNotesRef.current.value =
+              const superVal =
                 annotations.find(
                   (annotation) =>
                     annotation.parent_annotation === correctAnnotation.id,
                 )?.supercheck_notes ?? "";
-              try {
-                const newDelta2 =
-                  annotationNotesRef.current.value !== ""
-                    ? JSON.parse(annotationNotesRef.current.value)
-                    : "";
-                annotationNotesRef.current.getEditor().setContents(newDelta2);
-              } catch (err) {
-                if (err) {
-                  const newDelta2 = annotationNotesRef.current.value;
-                  annotationNotesRef.current.getEditor().setText(newDelta2);
-                }
-              }
 
-              try {
-                const newDelta1 =
-                  reviewNotesRef.current.value != ""
-                    ? JSON.parse(reviewNotesRef.current.value)
-                    : "";
-                reviewNotesRef.current.getEditor().setContents(newDelta1);
-              } catch (err) {
-                if (err) {
-                  const newDelta1 = reviewNotesRef.current.value;
-                  reviewNotesRef.current.getEditor().setText(newDelta1);
-                }
-              }
-              try {
-                const newDelta3 =
-                  superCheckerNotesRef.current.value != ""
-                    ? JSON.parse(superCheckerNotesRef.current.value)
-                    : "";
-                superCheckerNotesRef.current.getEditor().setContents(newDelta3);
-              } catch (err) {
-                if (err) {
-                  const newDelta3 = superCheckerNotesRef.current.value;
-                  superCheckerNotesRef.current.getEditor().setText(newDelta3);
-                }
-              }
-              setannotationtext(
-                annotationNotesRef.current.getEditor().getText(),
-              );
+              setAnnotationNotesValue(annoVal);
+              setReviewNotesValue(reviewVal);
+              setSuperCheckerNotesValue(superVal);
+
+              loadIntoEditor(annotationNotesRef, annoVal);
+              loadIntoEditor(reviewNotesRef, reviewVal);
+              loadIntoEditor(superCheckerNotesRef, superVal);
+
+              setannotationtext(annotationNotesRef.current.getEditor().getText());
               setreviewtext(reviewNotesRef.current.getEditor().getText());
-              setsupercheckertext(
-                superCheckerNotesRef.current.getEditor().getText(),
-              );
+              setsupercheckertext(superCheckerNotesRef.current.getEditor().getText());
             } else {
-              reviewNotesRef.current.value =
-                reviewerAnnotations[0].review_notes ?? "";
-              annotationNotesRef.current.value =
+              const reviewVal = reviewerAnnotations[0].review_notes ?? "";
+              const annoVal =
                 annotations.find(
                   (annotation) =>
                     annotation.id === reviewerAnnotations[0]?.parent_annotation,
                 )?.annotation_notes ?? "";
-              superCheckerNotesRef.current.value =
+              const superVal =
                 annotations.find(
                   (annotation) =>
                     annotation.parent_annotation === reviewerAnnotations[0]?.id,
                 )?.supercheck_notes ?? "";
-              try {
-                const newDelta2 =
-                  annotationNotesRef.current.value !== ""
-                    ? JSON.parse(annotationNotesRef.current.value)
-                    : "";
-                annotationNotesRef.current.getEditor().setContents(newDelta2);
-              } catch (err) {
-                if (err) {
-                  const newDelta2 = annotationNotesRef.current.value;
-                  annotationNotesRef.current.getEditor().setText(newDelta2);
-                }
-              }
 
-              try {
-                const newDelta1 =
-                  reviewNotesRef.current.value != ""
-                    ? JSON.parse(reviewNotesRef.current.value)
-                    : "";
-                reviewNotesRef.current.getEditor().setContents(newDelta1);
-              } catch (err) {
-                if (err) {
-                  const newDelta1 = reviewNotesRef.current.value;
-                  reviewNotesRef.current.getEditor().setText(newDelta1);
-                }
-              }
-              try {
-                const newDelta3 =
-                  superCheckerNotesRef.current.value != ""
-                    ? JSON.parse(superCheckerNotesRef.current.value)
-                    : "";
-                superCheckerNotesRef.current.getEditor().setContents(newDelta3);
-              } catch (err) {
-                if (err) {
-                  const newDelta3 = superCheckerNotesRef.current.value;
-                  superCheckerNotesRef.current.getEditor().setText(newDelta3);
-                }
-              }
+              setAnnotationNotesValue(annoVal);
+              setReviewNotesValue(reviewVal);
+              setSuperCheckerNotesValue(superVal);
 
-              setannotationtext(
-                annotationNotesRef.current.getEditor().getText(),
-              );
+              loadIntoEditor(annotationNotesRef, annoVal);
+              loadIntoEditor(reviewNotesRef, reviewVal);
+              loadIntoEditor(superCheckerNotesRef, superVal);
+
+              setannotationtext(annotationNotesRef.current.getEditor().getText());
               setreviewtext(reviewNotesRef.current.getEditor().getText());
-              setsupercheckertext(
-                superCheckerNotesRef.current.getEditor().getText(),
-              );
+              setsupercheckertext(superCheckerNotesRef.current.getEditor().getText());
             }
           } else {
             let normalAnnotation = annotations.find(
               (annotation) => annotation.annotation_type === 1,
             );
-            annotationNotesRef.current.value =
-              normalAnnotation.annotation_notes ?? "";
-            reviewNotesRef.current.value = normalAnnotation.review_notes ?? "";
-            superCheckerNotesRef.current.value =
-              normalAnnotation.supercheck_notes ?? "";
-            try {
-              const newDelta2 =
-                annotationNotesRef.current.value !== ""
-                  ? JSON.parse(annotationNotesRef.current.value)
-                  : "";
-              annotationNotesRef.current.getEditor().setContents(newDelta2);
-            } catch (err) {
-              if (err) {
-                const newDelta2 = annotationNotesRef.current.value;
-                annotationNotesRef.current.getEditor().setText(newDelta2);
-              }
-            }
 
-            try {
-              const newDelta1 =
-                reviewNotesRef.current.value != ""
-                  ? JSON.parse(reviewNotesRef.current.value)
-                  : "";
-              reviewNotesRef.current.getEditor().setContents(newDelta1);
-            } catch (err) {
-              if (err) {
-                const newDelta1 = reviewNotesRef.current.value;
-                reviewNotesRef.current.getEditor().setText(newDelta1);
-              }
-            }
-            try {
-              const newDelta3 =
-                superCheckerNotesRef.current.value != ""
-                  ? JSON.parse(superCheckerNotesRef.current.value)
-                  : "";
-              superCheckerNotesRef.current.getEditor().setContents(newDelta3);
-            } catch (err) {
-              if (err) {
-                const newDelta3 = superCheckerNotesRef.current.value;
-                superCheckerNotesRef.current.getEditor().setText(newDelta3);
-              }
-            }
+            const annoVal = normalAnnotation.annotation_notes ?? "";
+            const reviewVal = normalAnnotation.review_notes ?? "";
+            const superVal = normalAnnotation.supercheck_notes ?? "";
+
+            setAnnotationNotesValue(annoVal);
+            setReviewNotesValue(reviewVal);
+            setSuperCheckerNotesValue(superVal);
+
+            loadIntoEditor(annotationNotesRef, annoVal);
+            loadIntoEditor(reviewNotesRef, reviewVal);
+            loadIntoEditor(superCheckerNotesRef, superVal);
+
             setannotationtext(annotationNotesRef.current.getEditor().getText());
             setreviewtext(reviewNotesRef.current.getEditor().getText());
-            setsupercheckertext(
-              superCheckerNotesRef.current.getEditor().getText(),
-            );
+            setsupercheckertext(superCheckerNotesRef.current.getEditor().getText());
           }
         }
       }
@@ -549,12 +437,11 @@ const ReviewPage = () => {
   };
 
   const resetNotes = () => {
-    if (
-      annotationNotesRef.current &&
-      reviewNotesRef.current &&
-      superCheckerNotesRef.current
-    ) {
-      setShowNotes(false);
+    setAnnotationNotesValue("");
+    setReviewNotesValue("");
+    setSuperCheckerNotesValue("");
+    setShowNotes(false);
+    if (reviewNotesRef.current) {
       reviewNotesRef.current.getEditor().setContents([]);
     }
   };
@@ -1659,6 +1546,10 @@ return (
           bounds={"#note"}
           formats={formats}
           placeholder="Review Notes"
+          onChange={(_content, _delta, _source, editor) => {
+            setReviewNotesValue(JSON.stringify(editor.getContents()));
+            setreviewtext(editor.getText());
+          }}
         ></ReactQuill>
         <ReactQuill
           forwardedRef={superCheckerNotesRef}

--- a/src/app/ui/pages/chat/SuperCheckerPage.jsx
+++ b/src/app/ui/pages/chat/SuperCheckerPage.jsx
@@ -167,6 +167,11 @@ const SuperCheckerPage = () => {
   const [submittedEvalForms, setSubmittedEvalForms] = useState();
   const [isModelFailing, setIsModelFailing] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);
+
+  // ── useState replacements for the .value workaround on the refs ──
+  const [reviewNotesValue, setReviewNotesValue] = useState("");
+  const [superCheckerNotesValue, setSuperCheckerNotesValue] = useState("");
+
   if (typeof window !== "undefined") {
     window.localStorage.setItem("TaskData", JSON.stringify(taskData));
   }
@@ -233,6 +238,18 @@ const SuperCheckerPage = () => {
     setShowNotes(!showNotes);
   };
 
+  // Helper: load a value into a Quill editor via its ref
+  const loadIntoEditor = (ref, value) => {
+    try {
+      const delta = value !== "" ? JSON.parse(value) : "";
+      ref.current.getEditor().setContents(delta);
+    } catch (err) {
+      if (err) {
+        ref.current.getEditor().setText(value);
+      }
+    }
+  };
+
   const setNotes = (taskData, annotations) => {
     if (
       typeof window !== "undefined" &&
@@ -249,39 +266,18 @@ const SuperCheckerPage = () => {
           let reviewAnnotation = annotations.find(
             (annotation) => annotation.id === userAnnotation?.parent_annotation,
           );
-          reviewNotesRef.current.value = reviewAnnotation?.review_notes ?? "";
-          superCheckerNotesRef.current.value =
-            userAnnotation?.supercheck_notes ?? "";
 
-          try {
-            const newDelta1 =
-              reviewNotesRef.current.value != ""
-                ? JSON.parse(reviewNotesRef.current.value)
-                : "";
-            reviewNotesRef.current.getEditor().setContents(newDelta1);
-          } catch (err) {
-            if (err) {
-              const newDelta1 = reviewNotesRef.current.value;
-              reviewNotesRef.current.getEditor().setText(newDelta1);
-            }
-          }
-          try {
-            const newDelta3 =
-              superCheckerNotesRef.current.value != ""
-                ? JSON.parse(superCheckerNotesRef.current.value)
-                : "";
-            superCheckerNotesRef.current.getEditor().setContents(newDelta3);
-          } catch (err) {
-            if (err) {
-              const newDelta3 = superCheckerNotesRef.current.value;
-              superCheckerNotesRef.current.getEditor().setText(newDelta3);
-            }
-          }
+          const reviewVal = reviewAnnotation?.review_notes ?? "";
+          const superVal = userAnnotation?.supercheck_notes ?? "";
+
+          setReviewNotesValue(reviewVal);
+          setSuperCheckerNotesValue(superVal);
+
+          loadIntoEditor(reviewNotesRef, reviewVal);
+          loadIntoEditor(superCheckerNotesRef, superVal);
 
           setreviewtext(reviewNotesRef.current.getEditor().getText());
-          setsupercheckertext(
-            superCheckerNotesRef.current.getEditor().getText(),
-          );
+          setsupercheckertext(superCheckerNotesRef.current.getEditor().getText());
         } else {
           let reviewerAnnotations = annotations.filter(
             (value) => value?.annotation_type === 2,
@@ -296,81 +292,37 @@ const SuperCheckerPage = () => {
                 (annotation) =>
                   annotation.parent_annotation === correctAnnotation.id,
               );
-              reviewNotesRef.current.value =
-                correctAnnotation.review_notes ?? "";
-              superCheckerNotesRef.current.value =
-                superCheckerAnnotation.supercheck_notes ?? "";
 
-              try {
-                const newDelta1 =
-                  reviewNotesRef.current.value != ""
-                    ? JSON.parse(reviewNotesRef.current.value)
-                    : "";
-                reviewNotesRef.current.getEditor().setContents(newDelta1);
-              } catch (err) {
-                if (err) {
-                  const newDelta1 = reviewNotesRef.current.value;
-                  reviewNotesRef.current.getEditor().setText(newDelta1);
-                }
-              }
-              try {
-                const newDelta3 =
-                  superCheckerNotesRef.current.value != ""
-                    ? JSON.parse(superCheckerNotesRef.current.value)
-                    : "";
-                superCheckerNotesRef.current.getEditor().setContents(newDelta3);
-              } catch (err) {
-                if (err) {
-                  const newDelta3 = superCheckerNotesRef.current.value;
-                  superCheckerNotesRef.current.getEditor().setText(newDelta3);
-                }
-              }
+              const reviewVal = correctAnnotation.review_notes ?? "";
+              const superVal = superCheckerAnnotation.supercheck_notes ?? "";
+
+              setReviewNotesValue(reviewVal);
+              setSuperCheckerNotesValue(superVal);
+
+              loadIntoEditor(reviewNotesRef, reviewVal);
+              loadIntoEditor(superCheckerNotesRef, superVal);
 
               setreviewtext(reviewNotesRef.current.getEditor().getText());
-              setsupercheckertext(
-                superCheckerNotesRef.current.getEditor().getText(),
-              );
+              setsupercheckertext(superCheckerNotesRef.current.getEditor().getText());
             } else {
               let superCheckerAnnotation = annotations.find(
                 (annotation) =>
                   annotation.parent_annotation === reviewerAnnotations[0]?.id,
               );
-              reviewNotesRef.current.value =
-                reviewerAnnotations[0]?.review_notes ?? "";
-              if (superCheckerAnnotation) {
-                superCheckerNotesRef.current.value =
-                  superCheckerAnnotation[0]?.supercheck_notes ?? "";
-              }
 
-              try {
-                const newDelta1 =
-                  reviewNotesRef.current.value != ""
-                    ? JSON.parse(reviewNotesRef.current.value)
-                    : "";
-                reviewNotesRef.current.getEditor().setContents(newDelta1);
-              } catch (err) {
-                if (err) {
-                  const newDelta1 = reviewNotesRef.current.value;
-                  reviewNotesRef.current.getEditor().setText(newDelta1);
-                }
-              }
-              try {
-                const newDelta3 =
-                  superCheckerNotesRef.current.value != ""
-                    ? JSON.parse(superCheckerNotesRef.current.value)
-                    : "";
-                superCheckerNotesRef.current.getEditor().setContents(newDelta3);
-              } catch (err) {
-                if (err) {
-                  const newDelta3 = superCheckerNotesRef.current.value;
-                  superCheckerNotesRef.current.getEditor().setText(newDelta3);
-                }
-              }
+              const reviewVal = reviewerAnnotations[0]?.review_notes ?? "";
+              const superVal = superCheckerAnnotation
+                ? superCheckerAnnotation[0]?.supercheck_notes ?? ""
+                : "";
+
+              setReviewNotesValue(reviewVal);
+              setSuperCheckerNotesValue(superVal);
+
+              loadIntoEditor(reviewNotesRef, reviewVal);
+              loadIntoEditor(superCheckerNotesRef, superVal);
 
               setreviewtext(reviewNotesRef.current.getEditor().getText());
-              setsupercheckertext(
-                superCheckerNotesRef.current.getEditor().getText(),
-              );
+              setsupercheckertext(superCheckerNotesRef.current.getEditor().getText());
             }
           }
         }
@@ -448,12 +400,14 @@ const SuperCheckerPage = () => {
   };
 
   const resetNotes = () => {
+    setReviewNotesValue("");
+    setSuperCheckerNotesValue("");
+    setShowNotes(false);
     if (
       typeof window !== "undefined" &&
       annotationNotesRef.current &&
       reviewNotesRef.current
     ) {
-      setShowNotes(false);
       annotationNotesRef.current.getEditor().setContents([]);
       reviewNotesRef.current.getEditor().setContents([]);
     }
@@ -1437,6 +1391,10 @@ return (
           formats={formats}
           bounds={"#note"}
           placeholder="Superchecker Notes"
+          onChange={(_content, _delta, _source, editor) => {
+            setSuperCheckerNotesValue(JSON.stringify(editor.getContents()));
+            setsupercheckertext(editor.getText());
+          }}
         ></ReactQuill>
       </div>
 


### PR DESCRIPTION
Refactor note handling by replacing refs with state for review and superchecker notes. Update the loadIntoEditor helper function to set editor contents directly from state values.