### PR TITLE
feat: Add configurable system_prompt field in project creation & settings

### DIFF
--- a/src/Lib/Features/projects/projectFormSlice.js
+++ b/src/Lib/Features/projects/projectFormSlice.js
@@ -26,7 +26,8 @@ const initialFormState = {
   fixedModels: [],
   numSelectedModels: 0,
   defaultValue: 0,
-  questionsJSON: null
+  questionsJSON: null,
+  systemPrompt: ''
 };
 
 const initialState = {

--- a/src/app/new-project/newproject.js
+++ b/src/app/new-project/newproject.js
@@ -176,6 +176,7 @@ const CreateProject = () => {
   const [selectedLanguageModels, setSelectedLanguageModels] = useState(fixedModels);
   const [numSelectedModels, setNumSelectedModels] = useState(fixedModels.length);
   const [defaultValue, setDefaultValue] = useState(0);
+  const [systemPrompt, setSystemPrompt] = useState('');
 
   const handleTextareaChange = (event) => {
     setDefaultValue(event.target.value);
@@ -204,7 +205,8 @@ const CreateProject = () => {
       selectedLanguageModels,
       fixedModels,
       numSelectedModels,
-      defaultValue
+      defaultValue,
+      systemPrompt
     }));
   };
 
@@ -214,7 +216,7 @@ const CreateProject = () => {
     title, description, selectedDomain, selectedType, sourceLanguage, targetLanguage,
     selectedInstances, confirmed, samplingMode, random, batchSize, batchNumber,
     selectedAnnotatorsNum, taskReviews, createannotationsAutomatically, is_published, conceal, jsonInput, isModelSelectionEnabled, selectedLanguageModels,
-    fixedModels, numSelectedModels, defaultValue
+    fixedModels, numSelectedModels, defaultValue, systemPrompt
   ]);
     useEffect(() => {
     setTitle(formData.title);
@@ -240,6 +242,7 @@ const CreateProject = () => {
     setFixedModels(formData.fixedModels);
     setNumSelectedModels(formData.numSelectedModels);
     setDefaultValue(formData.defaultValue);
+    setSystemPrompt(formData.systemPrompt || '');
   }, []);
 
   // Clear form function
@@ -270,6 +273,7 @@ const CreateProject = () => {
     setFixedModels(fixed_Models);
     setNumSelectedModels();
     setDefaultValue(0);
+    setSystemPrompt('');
   };
 
   useEffect(() => {
@@ -611,6 +615,15 @@ const CreateProject = () => {
     };
   } else {
     baseMetadata = questionsJSON;
+  }
+
+  // Add system_prompt to metadata if provided
+  if (systemPrompt && systemPrompt.trim() !== '') {
+    if (typeof baseMetadata === 'object' && baseMetadata !== null) {
+      baseMetadata = { ...baseMetadata, system_prompt: systemPrompt.trim() };
+    } else {
+      baseMetadata = { system_prompt: systemPrompt.trim() };
+    }
   }
 
   if (workspaceDtails?.guest_workspace_display === "Yes") {
@@ -1144,12 +1157,13 @@ const CreateProject = () => {
                 </Grid>
               </Card>
             )}
-            {selectedType === "MultipleLLMInstructionDrivenChat" && selectedDomain === "Chat" && (
+            {(selectedType === "MultipleLLMInstructionDrivenChat" || selectedType === "InstructionDrivenChat") && selectedDomain === "Chat" && (
               <Card sx={{ p: 1, mb: 1 }}>
                 <Typography variant="h6" gutterBottom sx={{ mb: 2 }}>
                   Chat Configuration
                 </Typography>
 
+                {selectedType === "MultipleLLMInstructionDrivenChat" && (
                 <Grid container spacing={2} alignItems="center">
                   {/* Toggle on the left */}
                   <Grid item xs={12} md={2}>
@@ -1333,6 +1347,39 @@ const CreateProject = () => {
                   ) : null}
 
                 </Grid>
+                )}
+
+                  {/* System Prompt Field */}
+                  <Grid container spacing={2} sx={{ mt: 1 }}>
+                    <Grid item xs={12}>
+                      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                        <Typography variant="body2" sx={{ mr: 1, fontWeight: 'normal' }}>
+                          System Prompt:
+                          <Tooltip
+                            title="Optional custom system prompt for the LLM. If left empty, a default system prompt will be used."
+                            arrow
+                            placement="top"
+                          >
+                            <IconButton size="small" sx={{ color: 'primary.main' }}>
+                              <InfoOutlined fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        </Typography>
+                        <TextField
+                          fullWidth
+                          multiline
+                          minRows={3}
+                          maxRows={6}
+                          size="small"
+                          value={systemPrompt}
+                          onChange={(e) => setSystemPrompt(e.target.value)}
+                          placeholder="Enter a custom system prompt for the LLM (optional)"
+                          variant="outlined"
+                        />
+                      </Box>
+                    </Grid>
+                  </Grid>
+
               </Card>
             )}
             {/* {selectedType === "MultipleLLMInstructionDrivenChat" &&

--- a/src/components/Project/BasicSettings.jsx
+++ b/src/components/Project/BasicSettings.jsx
@@ -4,6 +4,9 @@ import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import IconButton from "@mui/material/IconButton";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import React, { useEffect, useState } from "react";
 import themeDefault from '@/themes/theme'
 import { useNavigate, useParams } from 'react-router-dom';
@@ -36,6 +39,7 @@ const BasicSettings = (props) => {
     const [languageOptions, setLanguageOptions] = useState([]);
     const [loading, setLoading] = useState(false);
     const [newDetails, setNewDetails] = useState();
+    const [systemPrompt, setSystemPrompt] = useState('');
     const { id } = useParams();
     const navigate = useNavigate();
     const classes = DatasetStyle();
@@ -84,6 +88,13 @@ const BasicSettings = (props) => {
         });
         setTargetLanguage(ProjectDetails?.tgt_language)
         setSourceLanguage(ProjectDetails?.src_language)
+        // Initialize system prompt from metadata_json
+        const metadata = ProjectDetails?.metadata_json;
+        if (metadata && typeof metadata === 'object' && metadata.system_prompt) {
+            setSystemPrompt(metadata.system_prompt);
+        } else {
+            setSystemPrompt('');
+        }
     }, [ProjectDetails]);
     const LanguageChoices = useSelector((state) => state.getLanguages.data.language);
    
@@ -109,6 +120,16 @@ const BasicSettings = (props) => {
 
 
     const handleSave = async () => {
+        // Build updated metadata_json with system_prompt
+        const existingMetadata = ProjectDetails?.metadata_json || {};
+        const updatedMetadata = {
+            ...(typeof existingMetadata === 'object' ? existingMetadata : {}),
+        };
+        if (systemPrompt && systemPrompt.trim() !== '') {
+            updatedMetadata.system_prompt = systemPrompt.trim();
+        } else {
+            delete updatedMetadata.system_prompt;
+        }
 
         const sendData = {
             title: newDetails.title,
@@ -122,6 +143,7 @@ const BasicSettings = (props) => {
             max_pending_tasks_per_user: newDetails.max_pending_tasks_per_user,
             tasks_pull_count_per_batch: newDetails.tasks_pull_count_per_batch,
             max_tasks_per_user: newDetails.max_tasks_per_user,
+            metadata_json: updatedMetadata,
         }
         console.log(sendData);
         const projectObj = new GetSaveButtonAPI(id, sendData);
@@ -482,6 +504,61 @@ const BasicSettings = (props) => {
                                     onChange={handleProjectName} />
                             </Grid>
                         </Grid>
+
+                        {/* System Prompt - Only for Chat project types */}
+                        {(ProjectDetails?.project_type === "InstructionDrivenChat" || ProjectDetails?.project_type === "MultipleLLMInstructionDrivenChat") && (
+                        <Grid
+                            container
+                            direction='row'
+                            sx={{
+                                alignItems: "flex-start",
+                                mt: 2
+                            }}
+                        >
+                            <Grid
+                                items
+                                xs={12}
+                                sm={12}
+                                md={12}
+                                lg={2}
+                                xl={2}
+                            >
+                                <Typography variant="body2" fontWeight='700' sx={{ mt: 1 }}>
+                                    System Prompt
+                                    <Tooltip
+                                        title="Optional custom system prompt for the LLM. If left empty, a default system prompt will be used."
+                                        arrow
+                                        placement="top"
+                                    >
+                                        <IconButton size="small" sx={{ color: 'primary.main' }}>
+                                            <InfoOutlinedIcon fontSize="small" />
+                                        </IconButton>
+                                    </Tooltip>
+                                </Typography>
+                            </Grid>
+                            <Grid
+                                item
+                                xs={12}
+                                md={12}
+                                lg={9}
+                                xl={9}
+                                sm={12}
+                            >
+                                <TextField
+                                    fullWidth
+                                    multiline
+                                    minRows={3}
+                                    maxRows={6}
+                                    size="small"
+                                    value={systemPrompt}
+                                    onChange={(e) => setSystemPrompt(e.target.value)}
+                                    placeholder="Enter a custom system prompt for the LLM (optional)"
+                                    variant="outlined"
+                                    inputProps={{ style: { fontSize: "14px" } }}
+                                />
+                            </Grid>
+                        </Grid>
+                        )}
                     </>
                 <Grid
                     container


### PR DESCRIPTION
#### Summary

Adds a new optional `System Prompt` textarea field to both the **project creation form** (Chat Configuration section) and the **project settings page** (Basic Settings tab), allowing users to configure a custom LLM system prompt per project.

#### Changes

**`src/Lib/Features/projects/projectFormSlice.js`**
- Added `systemPrompt` to `initialFormState` for Redux persistence.

**`src/app/new-project/newproject.js`**
- Added `systemPrompt` state variable with full Redux save/restore/clear wiring.
- Expanded Chat Configuration card to render for both `InstructionDrivenChat` and `MultipleLLMInstructionDrivenChat`.
- Multi-model-specific fields (Models, Fixed Models, etc.) are conditionally shown only for `MultipleLLMInstructionDrivenChat`.
- Added a **System Prompt** textarea (optional, multiline, 3–6 rows) with tooltip.
- Injects `system_prompt` into `metadata_json` on project creation when provided.

**`src/components/Project/BasicSettings.jsx`**
- Added `systemPrompt` state, initialized from `ProjectDetails.metadata_json.system_prompt`.
- Added System Prompt textarea in Basic Settings (visible only for Chat project types).
- On save, merges the updated `system_prompt` into the existing `metadata_json` and sends it via the PUT request.

#### Testing

- ✅ Create project with custom system prompt → stored in `metadata_json`
- ✅ Create project without system prompt → no `system_prompt` key in metadata, backend uses default
- ✅ Update system prompt via project settings → `metadata_json` updated correctly
- ✅ Clear system prompt via project settings → `system_prompt` key removed from metadata
- ✅ Field only appears for `InstructionDrivenChat` and `MultipleLLMInstructionDrivenChat` project types