### PR TITLE
feat: implement per-model configurable system prompts in UI

### DIFF
--- a/src/Lib/Features/projects/projectFormSlice.js
+++ b/src/Lib/Features/projects/projectFormSlice.js
@@ -27,7 +27,7 @@ const initialFormState = {
   numSelectedModels: 0,
   defaultValue: 0,
   questionsJSON: null,
-  systemPrompt: ''
+  systemPrompt: {}
 };
 
 const initialState = {

--- a/src/app/new-project/newproject.js
+++ b/src/app/new-project/newproject.js
@@ -176,7 +176,15 @@ const CreateProject = () => {
   const [selectedLanguageModels, setSelectedLanguageModels] = useState(fixedModels);
   const [numSelectedModels, setNumSelectedModels] = useState(fixedModels.length);
   const [defaultValue, setDefaultValue] = useState(0);
-  const [systemPrompt, setSystemPrompt] = useState('');
+  const DEFAULT_SYSTEM_PROMPT = "We will be rendering your response on a frontend. so please add spaces or indentation or nextline chars or bullet or numberings etc. suitably for code or the text. wherever required.";
+  const [systemPrompt, setSystemPrompt] = useState({});
+
+  const handleSystemPromptChange = (model, value) => {
+    setSystemPrompt(prev => ({
+      ...prev,
+      [model]: value
+    }));
+  };
 
   const handleTextareaChange = (event) => {
     setDefaultValue(event.target.value);
@@ -242,7 +250,7 @@ const CreateProject = () => {
     setFixedModels(formData.fixedModels);
     setNumSelectedModels(formData.numSelectedModels);
     setDefaultValue(formData.defaultValue);
-    setSystemPrompt(formData.systemPrompt || '');
+    setSystemPrompt(formData.systemPrompt || {});
   }, []);
 
   // Clear form function
@@ -273,7 +281,7 @@ const CreateProject = () => {
     setFixedModels(fixed_Models);
     setNumSelectedModels();
     setDefaultValue(0);
-    setSystemPrompt('');
+    setSystemPrompt({});
   };
 
   useEffect(() => {
@@ -618,11 +626,17 @@ const CreateProject = () => {
   }
 
   // Add system_prompt to metadata if provided
-  if (systemPrompt && systemPrompt.trim() !== '') {
-    if (typeof baseMetadata === 'object' && baseMetadata !== null) {
-      baseMetadata = { ...baseMetadata, system_prompt: systemPrompt.trim() };
-    } else {
-      baseMetadata = { system_prompt: systemPrompt.trim() };
+  if (systemPrompt && Object.keys(systemPrompt).length > 0) {
+    // Only save entries that are non-empty strings
+    const cleanedSystemPrompt = Object.fromEntries(
+      Object.entries(systemPrompt).filter(([k, v]) => v && v.trim() !== '')
+    );
+    if (Object.keys(cleanedSystemPrompt).length > 0) {
+      if (typeof baseMetadata === 'object' && baseMetadata !== null) {
+        baseMetadata = { ...baseMetadata, system_prompt: cleanedSystemPrompt };
+      } else {
+        baseMetadata = { system_prompt: cleanedSystemPrompt };
+      }
     }
   }
 
@@ -1349,35 +1363,67 @@ const CreateProject = () => {
                 </Grid>
                 )}
 
-                  {/* System Prompt Field */}
+                  {/* System Prompt Fields */}
                   <Grid container spacing={2} sx={{ mt: 1 }}>
-                    <Grid item xs={12}>
-                      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                        <Typography variant="body2" sx={{ mr: 1, fontWeight: 'normal' }}>
-                          System Prompt:
-                          <Tooltip
-                            title="Optional custom system prompt for the LLM. If left empty, a default system prompt will be used."
-                            arrow
-                            placement="top"
-                          >
-                            <IconButton size="small" sx={{ color: 'primary.main' }}>
-                              <InfoOutlined fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                        </Typography>
-                        <TextField
-                          fullWidth
-                          multiline
-                          minRows={3}
-                          maxRows={6}
-                          size="small"
-                          value={systemPrompt}
-                          onChange={(e) => setSystemPrompt(e.target.value)}
-                          placeholder="Enter a custom system prompt for the LLM (optional)"
-                          variant="outlined"
-                        />
-                      </Box>
-                    </Grid>
+                    {selectedType === "MultipleLLMInstructionDrivenChat" ? (
+                      selectedLanguageModels.map((model) => (
+                        <Grid item xs={12} key={model}>
+                          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                            <Typography variant="body2" sx={{ mr: 1, fontWeight: 'normal' }}>
+                              System Prompt for {model}:
+                              <Tooltip
+                                title={`Optional custom system prompt for ${model}.`}
+                                arrow
+                                placement="top"
+                              >
+                                <IconButton size="small" sx={{ color: 'primary.main' }}>
+                                  <InfoOutlined fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                            </Typography>
+                            <TextField
+                              fullWidth
+                              multiline
+                              minRows={3}
+                              maxRows={6}
+                              size="small"
+                              value={systemPrompt[model] !== undefined ? systemPrompt[model] : DEFAULT_SYSTEM_PROMPT}
+                              onChange={(e) => handleSystemPromptChange(model, e.target.value)}
+                              placeholder={`Enter a custom system prompt for ${model}`}
+                              variant="outlined"
+                            />
+                          </Box>
+                        </Grid>
+                      ))
+                    ) : (
+                      <Grid item xs={12}>
+                        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                          <Typography variant="body2" sx={{ mr: 1, fontWeight: 'normal' }}>
+                            System Prompt:
+                            <Tooltip
+                              title="Optional custom system prompt for the LLM."
+                              arrow
+                              placement="top"
+                            >
+                              <IconButton size="small" sx={{ color: 'primary.main' }}>
+                                <InfoOutlined fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          </Typography>
+                          <TextField
+                            fullWidth
+                            multiline
+                            minRows={3}
+                            maxRows={6}
+                            size="small"
+                            value={systemPrompt["default"] !== undefined ? systemPrompt["default"] : DEFAULT_SYSTEM_PROMPT}
+                            onChange={(e) => handleSystemPromptChange("default", e.target.value)}
+                            placeholder="Enter a custom system prompt for the LLM"
+                            variant="outlined"
+                          />
+                        </Box>
+                      </Grid>
+                    )}
                   </Grid>
 
               </Card>

--- a/src/components/Project/BasicSettings.jsx
+++ b/src/components/Project/BasicSettings.jsx
@@ -88,14 +88,14 @@ const BasicSettings = (props) => {
         });
         setTargetLanguage(ProjectDetails?.tgt_language)
         setSourceLanguage(ProjectDetails?.src_language)
-        // Initialize system prompt from metadata_json
         const metadata = ProjectDetails?.metadata_json;
-        if (metadata && typeof metadata === 'object' && metadata.system_prompt) {
+        if (metadata && typeof metadata === 'object' && metadata.system_prompt && typeof metadata.system_prompt === 'object') {
             setSystemPrompt(metadata.system_prompt);
         } else {
-            setSystemPrompt('');
+            setSystemPrompt({});
         }
     }, [ProjectDetails]);
+    const DEFAULT_SYSTEM_PROMPT = "We will be rendering your response on a frontend. so please add spaces or indentation or nextline chars or bullet or numberings etc. suitably for code or the text. wherever required.";
     const LanguageChoices = useSelector((state) => state.getLanguages.data.language);
    
     const getLanguageChoices = () => {
@@ -125,8 +125,15 @@ const BasicSettings = (props) => {
         const updatedMetadata = {
             ...(typeof existingMetadata === 'object' ? existingMetadata : {}),
         };
-        if (systemPrompt && systemPrompt.trim() !== '') {
-            updatedMetadata.system_prompt = systemPrompt.trim();
+        if (systemPrompt && Object.keys(systemPrompt).length > 0) {
+            const cleanedSystemPrompt = Object.fromEntries(
+                Object.entries(systemPrompt).filter(([k, v]) => v && v.trim() !== '')
+            );
+            if (Object.keys(cleanedSystemPrompt).length > 0) {
+                updatedMetadata.system_prompt = cleanedSystemPrompt;
+            } else {
+                delete updatedMetadata.system_prompt;
+            }
         } else {
             delete updatedMetadata.system_prompt;
         }
@@ -505,58 +512,73 @@ const BasicSettings = (props) => {
                             </Grid>
                         </Grid>
 
-                        {/* System Prompt - Only for Chat project types */}
+                        {/* System Prompt Fields - Only for Chat project types */}
                         {(ProjectDetails?.project_type === "InstructionDrivenChat" || ProjectDetails?.project_type === "MultipleLLMInstructionDrivenChat") && (
                         <Grid
                             container
-                            direction='row'
+                            direction='column'
                             sx={{
                                 alignItems: "flex-start",
                                 mt: 2
                             }}
                         >
-                            <Grid
-                                items
-                                xs={12}
-                                sm={12}
-                                md={12}
-                                lg={2}
-                                xl={2}
-                            >
-                                <Typography variant="body2" fontWeight='700' sx={{ mt: 1 }}>
-                                    System Prompt
-                                    <Tooltip
-                                        title="Optional custom system prompt for the LLM. If left empty, a default system prompt will be used."
-                                        arrow
-                                        placement="top"
-                                    >
-                                        <IconButton size="small" sx={{ color: 'primary.main' }}>
-                                            <InfoOutlinedIcon fontSize="small" />
-                                        </IconButton>
-                                    </Tooltip>
-                                </Typography>
-                            </Grid>
-                            <Grid
-                                item
-                                xs={12}
-                                md={12}
-                                lg={9}
-                                xl={9}
-                                sm={12}
-                            >
-                                <TextField
-                                    fullWidth
-                                    multiline
-                                    minRows={3}
-                                    maxRows={6}
-                                    size="small"
-                                    value={systemPrompt}
-                                    onChange={(e) => setSystemPrompt(e.target.value)}
-                                    placeholder="Enter a custom system prompt for the LLM (optional)"
-                                    variant="outlined"
-                                    inputProps={{ style: { fontSize: "14px" } }}
-                                />
-                            </Grid>
+                            {ProjectDetails?.project_type === "MultipleLLMInstructionDrivenChat" && ProjectDetails?.metadata_json?.models_set ? (
+                                ProjectDetails.metadata_json.models_set.map((model) => (
+                                    <Grid container direction='row' key={model} sx={{ alignItems: "flex-start", mt: 2 }}>
+                                        <Grid item xs={12} sm={12} md={12} lg={2} xl={2}>
+                                            <Typography variant="body2" fontWeight='700' sx={{ mt: 1 }}>
+                                                System Prompt for {model}
+                                                <Tooltip title={`Optional custom system prompt for ${model}.`} arrow placement="top">
+                                                    <IconButton size="small" sx={{ color: 'primary.main' }}>
+                                                        <InfoOutlinedIcon fontSize="small" />
+                                                    </IconButton>
+                                                </Tooltip>
+                                            </Typography>
+                                        </Grid>
+                                        <Grid item xs={12} md={12} lg={9} xl={9} sm={12}>
+                                            <TextField
+                                                fullWidth
+                                                multiline
+                                                minRows={3}
+                                                maxRows={6}
+                                                size="small"
+                                                value={systemPrompt[model] !== undefined ? systemPrompt[model] : DEFAULT_SYSTEM_PROMPT}
+                                                onChange={(e) => setSystemPrompt(prev => ({ ...prev, [model]: e.target.value }))}
+                                                placeholder={`Enter a custom system prompt for ${model}`}
+                                                variant="outlined"
+                                                inputProps={{ style: { fontSize: "14px" } }}
+                                            />
+                                        </Grid>
+                                    </Grid>
+                                ))
+                            ) : (
+                                <Grid container direction='row' sx={{ alignItems: "flex-start", mt: 2 }}>
+                                    <Grid item xs={12} sm={12} md={12} lg={2} xl={2}>
+                                        <Typography variant="body2" fontWeight='700' sx={{ mt: 1 }}>
+                                            System Prompt
+                                            <Tooltip title="Optional custom system prompt for the LLM. If left empty, a default system prompt will be used." arrow placement="top">
+                                                <IconButton size="small" sx={{ color: 'primary.main' }}>
+                                                    <InfoOutlinedIcon fontSize="small" />
+                                                </IconButton>
+                                            </Tooltip>
+                                        </Typography>
+                                    </Grid>
+                                    <Grid item xs={12} md={12} lg={9} xl={9} sm={12}>
+                                        <TextField
+                                            fullWidth
+                                            multiline
+                                            minRows={3}
+                                            maxRows={6}
+                                            size="small"
+                                            value={systemPrompt["default"] !== undefined ? systemPrompt["default"] : DEFAULT_SYSTEM_PROMPT}
+                                            onChange={(e) => setSystemPrompt(prev => ({ ...prev, "default": e.target.value }))}
+                                            placeholder="Enter a custom system prompt for the LLM"
+                                            variant="outlined"
+                                            inputProps={{ style: { fontSize: "14px" } }}
+                                        />
+                                    </Grid>
+                                </Grid>
+                            )}
                         </Grid>
                         )}
                     </>


### PR DESCRIPTION
## Description

This PR implements UI changes to support per-model configurable system prompts during project creation and editing. 

Previously, `InstructionDrivenChat` and `MultipleLLMInstructionDrivenChat` projects only supported a single `system_prompt` string that was applied to all language models. This PR refactors the frontend to store a dictionary mapping of models to their specific system prompts, allowing administrators to customize the system instructions individually for each LLM.

## Changes Included

- **State Management Refactor**: Changed `systemPrompt` in `projectFormSlice.js` and local component states from a string `""` to an empty object `{}`.
- **Dynamic Text Areas**: 
  - For `MultipleLLMInstructionDrivenChat` projects, the UI now iterates through the `selectedLanguageModels` and dynamically renders a separate system prompt text area for each model.
  - For standard `InstructionDrivenChat` projects, it displays a single text area mapped to a `"default"` key.
- **Pre-populated Defaults**: Hardcoded `DEFAULT_SYSTEM_PROMPT` into the frontend UI so that all text areas are automatically pre-populated with the default instructional string if no custom prompt has been set.
- **Backend Compatibility**: Adjusted the payload structure on save. Empty text areas are stripped out, and the model-to-prompt dictionary is correctly sent in the `metadata_json.system_prompt` field.
- **Affected Components**:
  - `src/Lib/Features/projects/projectFormSlice.js`
  - `src/app/new-project/newproject.js`
  - `src/components/Project/BasicSettings.jsx`

## Related Backend PR

https://github.com/AI4Bharat/Anudesh-Backend/pull/321

## Testing

1. Create a new `MultipleLLMInstructionDrivenChat` project.
2. Select multiple models (e.g., GPT3.5, GPT4).
3. Verify that multiple "System Prompt" fields appear (one for each model) and are pre-filled with the default system prompt.
4. Modify the prompts and save the project.
5. Verify in the Project Settings page that the custom prompts are correctly fetched and displayed for their respective models.
6. Test creating a standard `InstructionDrivenChat` project and verify it still functions correctly with a single generic system prompt field.
