### PR TITLE
Disable send button while waiting for LLM response for the previous prompt

### DIFF
--- a/src/components/Chat/TextArea.jsx
+++ b/src/components/Chat/TextArea.jsx
@@ -421,7 +421,7 @@ export default function Textarea({
             handleButtonClick();
             setText("");
           }}
-          disabled={!text?.trim()}
+          disabled={!text?.trim() || loading}
         >
           <SendRoundedIcon
                 style={{ color: "#EE6633", width: "32px", height: "32px" }}


### PR DESCRIPTION
Prevent another prompt from being sent to the LLM before the response is received for the previous prompt