### PR TITLE
Disable next prompt from being sent while previous prompt response fetch is in progress

### DIFF
--- a/src/components/Chat/TextArea.jsx
+++ b/src/components/Chat/TextArea.jsx
@@ -106,8 +106,10 @@ export default function Textarea({
   const handleKeyDown = (event) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
-      handleButtonClick();
-      setText("");
+      if (!loading) {
+        handleButtonClick();
+        setText("");
+      }
     } else if (event.key === "Enter" && event.shiftKey) {
       setText((prevText) => prevText + "\n");
     }


### PR DESCRIPTION
Disable next prompt from being sent through enter key while previous prompt response fetch is in progress