### PR TITLE
Feature/add gemini gemma4 models

### DIFF
--- a/src/app/new-project/models.js
+++ b/src/app/new-project/models.js
@@ -1,24 +1,17 @@
-const fixed_Models = [ "GPT3.5", "SARVAM_M" ]
+const fixed_Models = [ "google/gemma-4-26B-A4B-it", "google/gemma-4-31B-it" ]
 
 const languageModelOptions = [
-  "GPT3.5",
-  "GPT4",
-  "LLAMA2",
-  "GPT4OMini",
-  "GPT4O",
-  "SARVAM_M",
   "google/gemma-3-12b-it",
+  "google/gemma-3-27b-it",
+  "google/gemma-4-26B-A4B-it",
+  "google/gemma-4-31B-it",
   "Qwen/Qwen3-30B-A3B",
   "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
   "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-  "google/gemma-3-27b-it",
-  "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-  "meta-llama/Llama-3.2-3B-Instruct",
-  "meta-llama/Llama-3.3-70B-Instruct-Turbo",
-  "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-  "meta-llama/Llama-3.3-70B-Instruct",
-  "meta-llama/Meta-Llama-3.1-70B-Instruct",
-  "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  "gemini-3.5-flash",
+  "gemini-3.1-pro",
+  "gemini-3.1-flash-lite",
+  "gemini-3-flash",
   ];
 
 export { fixed_Models, languageModelOptions }

--- a/src/app/new-project/models.js
+++ b/src/app/new-project/models.js
@@ -9,9 +9,8 @@ const languageModelOptions = [
   "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
   "meta-llama/Llama-4-Scout-17B-16E-Instruct",
   "gemini-3.5-flash",
-  "gemini-3.1-pro",
+  "gemini-3.1-pro-preview",
   "gemini-3.1-flash-lite",
-  "gemini-3-flash",
   ];
 
 export { fixed_Models, languageModelOptions }

--- a/src/app/ui/pages/chat/inputBox.js
+++ b/src/app/ui/pages/chat/inputBox.js
@@ -124,8 +124,8 @@ const modelsData = [
         capabilities: { reasoning: true, image: true, voice: true },
       },
       {
-        id: 'gemini-3.1-pro',
-        name: 'Gemini 3.1 Pro',
+        id: 'gemini-3.1-pro-preview',
+        name: 'Gemini 3.1 Pro Preview',
         description: 'Advanced complex reasoning model',
         icon: <AutoAwesomeIcon sx={{ color: '#EA4335' }} />,
         capabilities: { reasoning: true, image: true, voice: true },
@@ -135,13 +135,6 @@ const modelsData = [
         name: 'Gemini 3.1 Flash Lite',
         description: 'Cost-efficient high-volume model',
         icon: <AutoAwesomeIcon sx={{ color: '#34A853' }} />,
-        capabilities: { reasoning: true, image: true, voice: true },
-      },
-      {
-        id: 'gemini-3-flash',
-        name: 'Gemini 3 Flash',
-        description: 'High-speed agentic model',
-        icon: <AutoAwesomeIcon sx={{ color: '#FBBC04' }} />,
         capabilities: { reasoning: true, image: true, voice: true },
       },
     ],
@@ -202,7 +195,7 @@ const formatPrompt = (prompt) => {
 function GuestChatPage() {
   const theme = useTheme();
   const dispatch = useDispatch();
-  const [selectedModel, setSelectedModel] = useState('gemini-3.5-flash');
+  const [selectedModel, setSelectedModel] = useState('google/gemma-4-26B-A4B-it');
   const [selectedLang, setSelectedLang] = useState("en");
   const [showLanguageSelect, setShowLanguageSelect] = useState(false);
   const [enableImageUpload, setEnableImageUpload] = useState(false);

--- a/src/app/ui/pages/chat/inputBox.js
+++ b/src/app/ui/pages/chat/inputBox.js
@@ -81,57 +81,12 @@ const lightTheme = createTheme({
 
 const modelsData = [
   {
-    provider: 'OpenAI',
-    models: [
-      {
-        id: 'GPT3.5',
-        name: 'GPT 3.5',
-        description: 'Advanced reasoning model',
-        icon: <AutoAwesomeIcon sx={{ color: '#8E44AD' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-      {
-        id: 'GPT4',
-        name: 'GPT 4',
-        description: 'Efficient reasoning model',
-        icon: <AutoAwesomeIcon sx={{ color: '#D252E4' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-      {
-        id: 'GPT4O',
-        name: 'GPT 4o',
-        description: 'Efficient reasoning model',
-        icon: <AutoAwesomeIcon sx={{ color: '#D252E4' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-      {
-        id: 'GPT4OMini',
-        name: 'GPT 4o Mini',
-        description: 'Efficient reasoning model',
-        icon: <AutoAwesomeIcon sx={{ color: '#D252E4' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-    ],
-  },
-  {
-    provider: 'Sarvam',
-    models: [
-      {
-        id: 'SARVAM_M',
-        name: 'Sarvam M',
-        description: 'Advanced hybrid-reasoning model',
-        icon: <BoltIcon sx={{ color: '#F39C12' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-    ],
-  },
-  {
     provider: 'Google',
     models: [
       {
         id: 'google/gemma-3-12b-it',
         name: 'Gemma 3 12B Instruct',
-        description: 'Advanced reasoning model',
+        description: 'Compact reasoning model',
         icon: <AutoAwesomeIcon sx={{ color: '#8E44AD' }} />,
         capabilities: { reasoning: true, image: false, voice: true },
       },
@@ -142,18 +97,58 @@ const modelsData = [
         icon: <AutoAwesomeIcon sx={{ color: '#D252E4' }} />,
         capabilities: { reasoning: true, image: false, voice: true },
       },
+      {
+        id: 'google/gemma-4-26B-A4B-it',
+        name: 'Gemma 4 26B A4B Instruct',
+        description: 'Multimodal MoE reasoning model',
+        icon: <AutoAwesomeIcon sx={{ color: '#4285F4' }} />,
+        capabilities: { reasoning: true, image: true, voice: true },
+      },
+      {
+        id: 'google/gemma-4-31B-it',
+        name: 'Gemma 4 31B Instruct',
+        description: 'Multimodal dense reasoning model',
+        icon: <AutoAwesomeIcon sx={{ color: '#4285F4' }} />,
+        capabilities: { reasoning: true, image: true, voice: true },
+      },
+    ],
+  },
+  {
+    provider: 'Gemini',
+    models: [
+      {
+        id: 'gemini-3.5-flash',
+        name: 'Gemini 3.5 Flash',
+        description: 'Fast agentic reasoning model',
+        icon: <AutoAwesomeIcon sx={{ color: '#4285F4' }} />,
+        capabilities: { reasoning: true, image: true, voice: true },
+      },
+      {
+        id: 'gemini-3.1-pro',
+        name: 'Gemini 3.1 Pro',
+        description: 'Advanced complex reasoning model',
+        icon: <AutoAwesomeIcon sx={{ color: '#EA4335' }} />,
+        capabilities: { reasoning: true, image: true, voice: true },
+      },
+      {
+        id: 'gemini-3.1-flash-lite',
+        name: 'Gemini 3.1 Flash Lite',
+        description: 'Cost-efficient high-volume model',
+        icon: <AutoAwesomeIcon sx={{ color: '#34A853' }} />,
+        capabilities: { reasoning: true, image: true, voice: true },
+      },
+      {
+        id: 'gemini-3-flash',
+        name: 'Gemini 3 Flash',
+        description: 'High-speed agentic model',
+        icon: <AutoAwesomeIcon sx={{ color: '#FBBC04' }} />,
+        capabilities: { reasoning: true, image: true, voice: true },
+      },
     ],
   },
   {
     provider: 'Meta',
     models: [
-      {
-        id: 'LLAMA2',
-        name: 'LLAMA2',
-        description: 'Advanced reasoning model',
-        icon: <HubIcon sx={{ color: '#3498DB' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
       {
         id: 'meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8',
         name: 'Llama 4 Maverick 17B 128E Instruct FP8',
@@ -167,55 +162,6 @@ const modelsData = [
         description: 'Advanced reasoning model',
         icon: <HubIcon sx={{ color: '#3498DB' }} />,
         capabilities: { reasoning: true, image: true, voice: true },
-      },
-      {
-        id: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
-        name: 'Meta Llama 3.1 8B Instruct Turbo',
-        description: 'Advanced reasoning model',
-        icon: <HubIcon sx={{ color: '#3498DB' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-      {
-        id: 'eta-llama/Llama-3.2-3B-Instruct',
-        name: 'Llama 3.2 3B Instruct',
-        description: 'Advanced reasoning model',
-        icon: <HubIcon sx={{ color: '#3498DB' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-      {
-        id: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
-        name: 'Llama 3.3 70B Instruct Turbo',
-        description: 'Advanced reasoning model',
-        icon: <HubIcon sx={{ color: '#3498DB' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-      {
-        id: 'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
-        name: 'Meta Llama 3.1 70B Instruct Turbo',
-        description: 'Advanced reasoning model',
-        icon: <HubIcon sx={{ color: '#3498DB' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-      {
-        id: 'meta-llama/Llama-3.3-70B-Instruct',
-        name: 'Llama 3.3 70B Instruct',
-        description: 'Advanced reasoning model',
-        icon: <HubIcon sx={{ color: '#3498DB' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-      {
-        id: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
-        name: 'Meta Llama 3.1 70B Instruct',
-        description: 'Advanced reasoning model',
-        icon: <HubIcon sx={{ color: '#3498DB' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
-      },
-      {
-        id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
-        name: 'Meta Llama 3.1 8B Instruct',
-        description: 'Advanced reasoning model',
-        icon: <HubIcon sx={{ color: '#3498DB' }} />,
-        capabilities: { reasoning: true, image: false, voice: true },
       },
     ],
   },
@@ -256,7 +202,7 @@ const formatPrompt = (prompt) => {
 function GuestChatPage() {
   const theme = useTheme();
   const dispatch = useDispatch();
-  const [selectedModel, setSelectedModel] = useState('GPT3.5');
+  const [selectedModel, setSelectedModel] = useState('gemini-3.5-flash');
   const [selectedLang, setSelectedLang] = useState("en");
   const [showLanguageSelect, setShowLanguageSelect] = useState(false);
   const [enableImageUpload, setEnableImageUpload] = useState(false);


### PR DESCRIPTION
### Summary
Update UI model selectors to add new Gemini 3.x and Gemma 4 models, retire legacy model entries, and fix incorrect model identifiers.

### Changes

#### `src/app/new-project/models.js`
- **Removed** non-existent `gemini-3-flash` from `languageModelOptions`
- **Fixed** `gemini-3.1-pro` → `gemini-3.1-pro-preview`

#### `src/app/ui/pages/chat/inputBox.js`
- **Removed** Gemini 3 Flash model card from the model picker
- **Fixed** Gemini 3.1 Pro → Gemini 3.1 Pro Preview (id and display name)
- **Changed** default selected model from `gemini-3.5-flash` to `google/gemma-4-26B-A4B-it`

### Testing
- Model IDs match the backend `LLM_CHOICES` and `ACTIVE_LLM_MODELS` definitions
- Verified correct model names against Google AI Studio API
