### PR TITLE
Feature: Bulk Update Button for Single IDC Tasks

### DIFF
--- a/src/app/new-project/models.js
+++ b/src/app/new-project/models.js
@@ -1,4 +1,3 @@
-// const fixed_Models = [ "GPT3.5", "SARVAM_M" ]
 const fixed_Models = ["google/gemma-4-26B-A4B-it", "google/gemma-4-31B-it"]
 
 const languageModelOptions = [
@@ -18,13 +17,19 @@ const languageModelOptions = [
   "gemini-3.5-flash",
   "gemini-3.1-pro-preview",
   "gemini-3.1-flash-lite",
-  // "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-  // "meta-llama/Llama-3.2-3B-Instruct",
-  // "meta-llama/Llama-3.3-70B-Instruct-Turbo",
-  // "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-  // "meta-llama/Llama-3.3-70B-Instruct",
-  // "meta-llama/Meta-Llama-3.1-70B-Instruct",
-  // "meta-llama/Meta-Llama-3.1-8B-Instruct"
 ];
 
-export { fixed_Models, languageModelOptions }
+const ACTIVE_LLM_MODELS = [
+  "google/gemma-3-12b-it",
+  "google/gemma-3-27b-it",
+  "google/gemma-4-26B-A4B-it",
+  "google/gemma-4-31B-it",
+  "Qwen/Qwen3-30B-A3B",
+  "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+  "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+  "gemini-3.5-flash",
+  "gemini-3.1-pro-preview",
+  "gemini-3.1-flash-lite",
+];
+
+export { fixed_Models, languageModelOptions, ACTIVE_LLM_MODELS }

--- a/src/components/Project/AdvancedOperation.jsx
+++ b/src/components/Project/AdvancedOperation.jsx
@@ -47,7 +47,8 @@ import LoginAPI from "@/app/actions/api/user/Login";
 import GetSaveButtonAPI from "@/app/actions/api/Projects/getSaveButtonAPI";
 import TasksassignDialog from './taskassign';
 import { fixed_Models, languageModelOptions } from "../../app/new-project/models";
-
+import UpdateInactiveModelsDialog from "./UpdateInactiveModelsDialog";
+/* eslint-disable react-hooks/exhaustive-deps */
 const ProgressType = [
   "incomplete",
   "annotated",
@@ -100,6 +101,7 @@ const AdvancedOperation = (props) => {
   });
   const [open, setOpen] = useState(false);
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
+  const [openUpdateModelDialog, setOpenUpdateModelDialog] = useState(false);
   const [loading, setLoading] = useState(false);
   const [newDetails, setNewDetails] = useState();
   const [OpenExportProjectDialog, setOpenExportProjectDialog] = useState(false);
@@ -868,6 +870,24 @@ const AdvancedOperation = (props) => {
           <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
             <DeallocationAnnotatorsAndReviewers />
           </Grid>
+          {ProjectDetails?.project_type === "InstructionDrivenChat" && (
+            <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
+              <Tooltip title="Update incomplete tasks with inactive models to a new active model">
+                <span>
+                  <CustomButton
+                    sx={{
+                      inlineSize: "max-content",
+                      borderRadius: 3,
+                      width: "100%",
+                      height: "50px",
+                    }}
+                    onClick={() => setOpenUpdateModelDialog(true)}
+                    label="Update Inactive Models"
+                  />
+                </span>
+              </Tooltip>
+            </Grid>
+          )}
         </Grid>
 
         <Grid
@@ -1355,7 +1375,12 @@ const AdvancedOperation = (props) => {
             </Button>
           </DialogActions>
         </Dialog>
-        
+        <UpdateInactiveModelsDialog
+          open={openUpdateModelDialog}
+          handleClose={() => setOpenUpdateModelDialog(false)}
+          projectId={id}
+          setSnackbarInfo={setSnackbarInfo}
+        />
         {OpenExportProjectDialog && (
           <ExportProjectDialog
             OpenExportProjectDialog={OpenExportProjectDialog}

--- a/src/components/Project/UpdateInactiveModelsDialog.jsx
+++ b/src/components/Project/UpdateInactiveModelsDialog.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+import CustomButton from "@/components/common/Button";
+import { ACTIVE_LLM_MODELS } from "@/app/new-project/models";
+
+const UpdateInactiveModelsDialog = ({ open, handleClose, projectId, setSnackbarInfo }) => {
+    const [selectedModel, setSelectedModel] = useState(null);
+    const [loading, setLoading] = useState(false);
+
+    const handleUpdate = async () => {
+        if (!selectedModel) {
+            setSnackbarInfo({
+                open: true,
+                message: "Please select a model.",
+                variant: "error",
+            });
+            return;
+        }
+
+        setLoading(true);
+        try {
+            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/projects/${projectId}/update_idc_tasks_model/`, {
+                method: "POST",
+                credentials: "include",
+                mode: "cors",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `JWT ${localStorage.getItem('anudesh_access_token')}`
+                },
+                body: JSON.stringify({ new_model: selectedModel }),
+            });
+            const data = await res.json();
+            setLoading(false);
+
+            if (res.ok) {
+                setSnackbarInfo({
+                    open: true,
+                    message: data.message || "Tasks successfully updated",
+                    variant: "success",
+                });
+                handleClose();
+            } else {
+                setSnackbarInfo({
+                    open: true,
+                    message: data.message || data.detail || "Update failed",
+                    variant: "error",
+                });
+            }
+        } catch (err) {
+            setLoading(false);
+            console.error(err);
+            setSnackbarInfo({
+                open: true,
+                message: "An error occurred while updating the tasks",
+                variant: "error",
+            });
+        }
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+            <DialogTitle>Update Inactive Models</DialogTitle>
+            <DialogContent>
+                <DialogContentText sx={{ mb: 2 }}>
+                    Select an active model to replace inactive models in all incomplete tasks for this project.
+                </DialogContentText>
+                <Autocomplete
+                    options={ACTIVE_LLM_MODELS}
+                    value={selectedModel}
+                    onChange={(event, newValue) => setSelectedModel(newValue)}
+                    renderInput={(params) => <TextField {...params} label="Select Active Model" variant="outlined" />}
+                />
+            </DialogContent>
+            <DialogActions sx={{ p: 2 }}>
+                <CustomButton onClick={handleClose} label="Cancel" sx={{ mr: 1 }} />
+                <CustomButton onClick={handleUpdate} label={loading ? "Updating..." : "Update"} disabled={loading} />
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default UpdateInactiveModelsDialog;


### PR DESCRIPTION
### Summary
Added a "Update Inactive Models" feature to the Project Settings page (Advanced Operations) for `InstructionDrivenChat` projects. This feature provides a simple UI for data leads to select a new active model and bulk update all incomplete tasks that are currently assigned a deprecated or inactive model.

### Changes
#### `src/components/Project/UpdateInactiveModelsDialog.jsx`
- Handles API communication via a `POST` request to the backend's `/projects/${projectId}/update_idc_tasks_model/` endpoint with the selected `new_model` payload.
- Provides immediate visual feedback through snackbar notifications on success or failure of the bulk update.

#### `src/components/Project/AdvancedOperation.jsx`
- Integrated the `UpdateInactiveModelsDialog` component.
- Added a new "Update Inactive Models" button to the project settings grid.
- Conditionally renders the button strictly for projects where `ProjectDetails?.project_type === "InstructionDrivenChat"`.

#### `src/app/new-project/models.js`
- Exported the `ACTIVE_LLM_MODELS` list ensuring synchronization with backend acceptable choices.
- Merged latest updates from `develop`, maintaining support for new and corrected model additions.

### Testing
- Validated UI rendering condition (button only visible on IDC projects).
- Tested the dropdown population logic ensuring only `ACTIVE_LLM_MODELS` can be selected.
- Successfully performed an end-to-end bulk update API request triggering the backend to process the model changes.
