### PR TITLE
feat: useStreamingLLM finish_reason support & ReactQuill typing bug fix

### DIFF
--- a/src/app/ui/pages/chat/AnnotatePage.jsx
+++ b/src/app/ui/pages/chat/AnnotatePage.jsx
@@ -232,7 +232,9 @@ const AnnotatePage = () => {
         reviewNotesRef.current.getEditor &&
         reviewNotesRef.current.getEditor()
       ) {
-        loadNotesIntoEditors(annotationNotesValue, reviewNotesValue);
+        const annoValue = AnnotationsTaskDetails[0].annotation_notes ?? "";
+        const reviewValue = AnnotationsTaskDetails[0].review_notes ?? "";
+        loadNotesIntoEditors(annoValue, reviewValue);
       }
     };
 
@@ -248,7 +250,8 @@ const AnnotatePage = () => {
     check();
 
     return () => clearTimeout(timeoutId);
-  }, [AnnotationsTaskDetails, annotationNotesValue, reviewNotesValue]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [AnnotationsTaskDetails]);
 
   useEffect(() => {
     resetNotes();

--- a/src/hooks/useStreamingLLM.js
+++ b/src/hooks/useStreamingLLM.js
@@ -12,7 +12,7 @@ import configs from "@/config/config";
  *     history: [{prompt: "hi", output: "hello"}],
  *     model: "google/gemma-4-26B-A4B-it",
  *     onToken: (token) => { ... },        // called for each streamed token
- *     onDone: (fullText) => { ... },       // called when stream completes
+ *     onDone: (fullText, finishReason) => { ... }, // called when stream completes; finishReason is "stop", "length", or null
  *     onError: (errorMsg) => { ... },      // called on error
  *   });
  */
@@ -76,14 +76,20 @@ export default function useStreamingLLM() {
 
             const dataStr = trimmed.slice(6); // remove "data: " prefix
 
-            // Check for stream completion
+            // Legacy stream completion (plain text sentinel)
             if (dataStr === "[DONE]") {
-              if (onDone) onDone(fullText);
+              if (onDone) onDone(fullText, null);
               return fullText;
             }
 
             try {
               const parsed = JSON.parse(dataStr);
+
+              // JSON stream completion with finish_reason
+              if (parsed.done) {
+                if (onDone) onDone(fullText, parsed.finish_reason || null);
+                return fullText;
+              }
 
               if (parsed.error) {
                 if (onError) onError(parsed.error);
@@ -103,7 +109,7 @@ export default function useStreamingLLM() {
 
         // If stream ended without [DONE], still call onDone
         if (fullText && onDone) {
-          onDone(fullText);
+          onDone(fullText, null);
         }
         return fullText;
       } catch (err) {
@@ -138,7 +144,7 @@ export default function useStreamingLLM() {
    * @param {Array} options.models - List of model names to stream from
    * @param {Object} options.systemPromptData - Per-model system prompts (optional)
    * @param {Function} options.onToken - Called with (modelName, token, fullTextForModel)
-   * @param {Function} options.onModelDone - Called with (modelName, fullTextForModel) when a model finishes
+   * @param {Function} options.onModelDone - Called with (modelName, fullTextForModel, finishReason) when a model finishes
    * @param {Function} options.onDone - Called with ({modelName: fullText, ...}) when all models finish
    * @param {Function} options.onError - Called with (errorMsg) on error
    */
@@ -200,6 +206,7 @@ export default function useStreamingLLM() {
 
             const dataStr = trimmed.slice(6);
 
+            // Legacy plain text sentinel
             if (dataStr === "[DONE]") {
               if (onDone) onDone(modelTexts);
               return modelTexts;
@@ -207,6 +214,12 @@ export default function useStreamingLLM() {
 
             try {
               const parsed = JSON.parse(dataStr);
+
+              // Global done (all models finished)
+              if (parsed.done && !parsed.model) {
+                if (onDone) onDone(modelTexts);
+                return modelTexts;
+              }
 
               if (parsed.error && !parsed.model) {
                 // Global error
@@ -222,8 +235,8 @@ export default function useStreamingLLM() {
               }
 
               if (parsed.done && parsed.model) {
-                // A single model finished
-                if (onModelDone) onModelDone(parsed.model, modelTexts[parsed.model] || "");
+                // A single model finished — includes finish_reason
+                if (onModelDone) onModelDone(parsed.model, modelTexts[parsed.model] || "", parsed.finish_reason || null);
                 continue;
               }
 


### PR DESCRIPTION
## Overview
This PR updates the streaming hook to support new backend signals and fixes a severe typing issue in the AnnotatePage notes editor.

## Key Changes
- **SSE `finish_reason` parsing**: Updated `useStreamingLLM` to parse the new JSON-based `[DONE]` events. The hook now successfully extracts `finish_reason` and passes it to the `onDone` and `onModelDone` callbacks. This allows the UI to surface warnings if the model is truncated mid-sentence due to length constraints. 
  - *Note: Maintained fallback parsing for the legacy plain text `[DONE]` event for backward compatibility.*
- **Annotation Notes Typing Fix**: Fixed a bug in `AnnotatePage.jsx` where text typed into the Annotation or Review notes would appear backward (e.g. "hello" became "olleh"). This was caused by a `useEffect` hook listening to the `annotationNotesValue` state and forcefully calling `editor.setContents()` on every keystroke, resetting the cursor to index 0. Initial values are now safely loaded exactly once via `AnnotationsTaskDetails` on mount.
