### PR TITLE
Fix Disappearing Chat History After LLM Streaming in Multiple LLM Tasks

### DIFF
--- a/src/app/ui/pages/chat/AnnotatePage.jsx
+++ b/src/app/ui/pages/chat/AnnotatePage.jsx
@@ -468,20 +468,20 @@ const AnnotatePage = () => {
   }
 
   const areAllFormsAnswered = () => {
-  if (!chatHistory || chatHistory.length === 0) return false;
-  
-  const lastTurn = chatHistory[chatHistory.length - 1];
-  const lastPromptOutputPairId = String(lastTurn.prompt_output_pair_id);
-  
-  const isLatestFormSubmitted = submittedEvalForms && 
-  submittedEvalForms.hasOwnProperty(lastPromptOutputPairId);
-  
-  return isLatestFormSubmitted;
-  };  
+    if (!chatHistory || chatHistory.length === 0) return false;
+
+    const lastTurn = chatHistory[chatHistory.length - 1];
+    const lastPromptOutputPairId = String(lastTurn.prompt_output_pair_id);
+
+    const isLatestFormSubmitted = submittedEvalForms &&
+      submittedEvalForms.hasOwnProperty(lastPromptOutputPairId);
+
+    return isLatestFormSubmitted;
+  };
 
   const buildResult = (value, type, resultValue) => {
     let result = resultValue;
-    
+
     if (value === "delete") {
       result = []
     }
@@ -498,28 +498,28 @@ const AnnotatePage = () => {
       };
     }
     else if (
-      value === "delete-pair" 
+      value === "delete-pair"
     ) {
-      result  = resultValue.slice(0, resultValue.length - 1)
+      result = resultValue.slice(0, resultValue.length - 1)
     }
     else {
       resultValue
-    }    
+    }
     return !Array.isArray(result) ? [result] : result;
   };
 
   const handleAnnotationClick = async (value, id, lead_time, type = "") => {
-    if (value === "delete" ) {
+    if (value === "delete") {
       setEvalFormResponse();
       setSubmittedEvalForms();
     }
-        console.log(submittedEvalForms,"hello");
+    console.log(submittedEvalForms, "hello");
 
     if (
       value === "labeled" &&
       type === "MultipleLLMInstructionDrivenChat" &&
       !areAllFormsAnswered()
-    ) {      
+    ) {
       console.log(areAllFormsAnswered);
 
       setSnackbarInfo({
@@ -592,7 +592,7 @@ const AnnotatePage = () => {
 
       resultValue = [
         {
-          eval_form: submittedEvalForms?Object.values(submittedEvalForms):[],
+          eval_form: submittedEvalForms ? Object.values(submittedEvalForms) : [],
           model_interactions: model_interactions,
         },
       ];
@@ -604,8 +604,8 @@ const AnnotatePage = () => {
     const liveAnnotationNotes =
       typeof window !== "undefined"
         ? JSON.stringify(
-            annotationNotesRef?.current?.getEditor().getContents(),
-          )
+          annotationNotesRef?.current?.getEditor().getContents(),
+        )
         : null;
 
     const PatchAPIdata = {
@@ -646,7 +646,7 @@ const AnnotatePage = () => {
         } else if (
           (ProjectDetails.project_type == "InstructionDrivenChat" ||
             ProjectDetails.project_type ==
-              "MultipleLLMInstructionDrivenChat") &&
+            "MultipleLLMInstructionDrivenChat") &&
           chatHistory.length == 0
         ) {
           setSnackbarInfo({
@@ -679,13 +679,17 @@ const AnnotatePage = () => {
             Array.isArray(allModelsInteractions) &&
             allModelsInteractions.length > 0
           ) {
-            const interactions_length =
-              allModelsInteractions[0]?.interaction_json?.length || 0;
+            const interactions_length = Math.max(
+              ...allModelsInteractions.map((m) => m?.interaction_json?.length || 0),
+              0
+            );
             let modifiedChatHistory = [];
             let globalModelFailure = false;
 
             for (let i = 0; i < interactions_length; i++) {
-              const prompt = allModelsInteractions[0]?.interaction_json[i]?.prompt;
+              const prompt = allModelsInteractions.find(
+                (m) => m?.interaction_json?.[i]?.prompt
+              )?.interaction_json?.[i]?.prompt;
               const modelOutputs = [];
               let turnPromptOutputPairId = null;
               let turnHasModelFailure = false;
@@ -697,16 +701,16 @@ const AnnotatePage = () => {
                   if (!response_valid) {
                     turnHasModelFailure = true;
                   }
-                  if (modelIdx === 0) {
-                    turnPromptOutputPairId = interaction?.prompt_output_pair_id;
+                  if (interaction?.prompt_output_pair_id) {
+                    turnPromptOutputPairId = interaction.prompt_output_pair_id;
                   }
                   modelOutputs.push({
                     model_name: modelData?.model_name,
                     output: response_valid
                       ? formatResponse(interaction?.output)
                       : formatResponse(
-                          `${modelData?.model_name} failed to generate a response`,
-                        ),
+                        `${modelData?.model_name} failed to generate a response`,
+                      ),
                     status: response_valid ? "success" : "error",
                     prompt_output_pair_id: interaction?.prompt_output_pair_id,
                     output_error: response_valid
@@ -757,7 +761,7 @@ const AnnotatePage = () => {
             setChatHistory([...modifiedChatHistory]);
           } else {
             setChatHistory([]);
-            setIsModelFailing(false); 
+            setIsModelFailing(false);
           }
         } else {
           let modifiedChatHistory = resp?.result.map((interaction) => {
@@ -766,10 +770,10 @@ const AnnotatePage = () => {
               output: formatResponse(interaction.output),
             };
           });
-          
+
           setChatHistory([...modifiedChatHistory]);
         }
-      } 
+      }
       if (res.ok) {
         if ((value === "delete" || value === "delete-pair") === false) {
           if (typeof window !== "undefined") {
@@ -780,23 +784,23 @@ const AnnotatePage = () => {
         }
         value === "delete"
           ? (setSnackbarInfo({
-              open: true,
-              message: "Chat history has been cleared successfully!",
-              variant: "success",
-            }),
+            open: true,
+            message: "Chat history has been cleared successfully!",
+            variant: "success",
+          }),
             await getAnnotationsTaskData(taskId),
             await getTaskData(taskId))
           : value === "delete-pair"
             ? setSnackbarInfo({
-                open: true,
-                message: "Selected conversation is deleted",
-                variant: "success",
-              })
+              open: true,
+              message: "Selected conversation is deleted",
+              variant: "success",
+            })
             : setSnackbarInfo({
-                open: true,
-                message: resp?.message,
-                variant: "success",
-              });
+              open: true,
+              message: resp?.message,
+              variant: "success",
+            });
         setLoading(false);
       } else {
         setAutoSave(true);
@@ -1101,15 +1105,15 @@ const AnnotatePage = () => {
       <div id="top" ref={topref}></div>
       <Grid container sx={{ overflow: "hidden" }}>
         {renderSnackBar()}
-        
+
         <Grid item xs={12} >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1,margin:'0.5rem',  flexWrap: 'wrap' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, margin: '0.5rem', flexWrap: 'wrap' }}>
             <Button
               startIcon={<ArrowBackIcon />}
               variant="contained"
               color="primary"
               size="small"
-              sx={{ 
+              sx={{
                 minWidth: 'auto',
                 fontSize: '0.75rem',
                 px: 1.5,
@@ -1119,7 +1123,7 @@ const AnnotatePage = () => {
                 if (typeof window !== "undefined") {
                   localStorage.removeItem("labelAll");
                 }
-                navigate(`/projects/${projectId}`,  { replace : true, state: { fromBackToProject: true } } );
+                navigate(`/projects/${projectId}`, { replace: true, state: { fromBackToProject: true } });
               }}
             >
               Back
@@ -1131,24 +1135,24 @@ const AnnotatePage = () => {
               color={reviewtext.trim().length === 0 ? "primary" : "success"}
               size="small"
               onClick={handleCollapseClick}
-              sx={{ 
+              sx={{
                 minWidth: 'auto',
                 fontSize: '0.75rem',
                 px: 1.5,
-                py: 0.2,                
+                py: 0.2,
                 backgroundColor: reviewtext.trim().length === 0 ? "#bf360c" : "green",
               }}
             >
               Notes {reviewtext.trim().length === 0 ? "" : "*"}
             </Button>
 
-            
+
             <LightTooltip
               title={
                 <div>
                   <div>
                     {ProjectDetails?.conceal == false &&
-                    Array.isArray(assignedUsers)
+                      Array.isArray(assignedUsers)
                       ? assignedUsers.join(", ")
                       : assignedUsers || "No assigned users"}
                   </div>
@@ -1204,7 +1208,7 @@ const AnnotatePage = () => {
                       minWidth: 'auto',
                       fontSize: '0.75rem',
                       px: 1.5,
-                      py: 0.2,                      color: "black",
+                      py: 0.2, color: "black",
                       border: "0px",
                       backgroundColor: "#ffe0b2",
                     }}
@@ -1223,7 +1227,7 @@ const AnnotatePage = () => {
                   minWidth: 'auto',
                   fontSize: '0.75rem',
                   px: 1.5,
-                  py: 0.2,                  color: "black",
+                  py: 0.2, color: "black",
                   border: "0px",
                   backgroundColor: "#ffe0b2",
                 }}
@@ -1251,7 +1255,7 @@ const AnnotatePage = () => {
                       minWidth: 'auto',
                       fontSize: '0.75rem',
                       px: 1.5,
-                      py: 0.2,                      color: "black",
+                      py: 0.2, color: "black",
                       border: "0px",
                       backgroundColor: "#ffe0b2",
                     }}
@@ -1268,7 +1272,7 @@ const AnnotatePage = () => {
                 <Tooltip
                   title={
                     ProjectDetails?.project_type == "InstructionDrivenChat" ||
-                    ProjectDetails?.project_type ==
+                      ProjectDetails?.project_type ==
                       "MultipleLLMInstructionDrivenChat"
                       ? "Clear the entire chat history"
                       : "Reset the entire chat history"
@@ -1288,13 +1292,13 @@ const AnnotatePage = () => {
                       minWidth: 'auto',
                       fontSize: '0.75rem',
                       px: 1.5,
-                      py: 0.2,                      color: "black",
+                      py: 0.2, color: "black",
                       border: "0px",
                       backgroundColor: "#ffe0b2",
                     }}
                   >
                     {ProjectDetails?.project_type == "InstructionDrivenChat" ||
-                    ProjectDetails?.project_type ==
+                      ProjectDetails?.project_type ==
                       "MultipleLLMInstructionDrivenChat"
                       ? "Clear Chats"
                       : "Reset All"}
@@ -1314,7 +1318,7 @@ const AnnotatePage = () => {
                     onClick={() => {
                       if (
                         ProjectDetails?.project_type ===
-                          "MultipleLLMInstructionDrivenChat" &&
+                        "MultipleLLMInstructionDrivenChat" &&
                         isModelFailing
                       ) {
                         setSnackbarInfo({
@@ -1338,7 +1342,7 @@ const AnnotatePage = () => {
                       minWidth: 'auto',
                       fontSize: '0.75rem',
                       px: 1.5,
-                      py: 0.2,                      color: "black",
+                      py: 0.2, color: "black",
                       border: "0px",
                       backgroundColor: "#ee6633",
                     }}

--- a/src/app/ui/pages/chat/ReviewPage.jsx
+++ b/src/app/ui/pages/chat/ReviewPage.jsx
@@ -501,7 +501,7 @@ const ReviewPage = () => {
       maxIdAnnotation?.id === task?.correct_annotation_id;
 
 
-      maxIdAnnotation?.id === task?.correct_annotation_id;
+    maxIdAnnotation?.id === task?.correct_annotation_id;
 
 
     const nextAPIData = {
@@ -540,7 +540,7 @@ const ReviewPage = () => {
             localStorage.removeItem("labelAll");
           }
 
-          window.location.replace(`/#/projects/${ projectId }`);
+          window.location.replace(`/#/projects/${projectId}`);
         }, 1000);
       });
     // }
@@ -551,7 +551,7 @@ const ReviewPage = () => {
       if (id) {
         resetNotes();
         // navigate(`/projects/${projectId}/task/${id}`, {replace: true});
-        navigate(`/projects/${ projectId }/review/${ id }`);
+        navigate(`/projects/${projectId}/review/${id}`);
       } else {
         // navigate(-1);
         resetNotes();
@@ -565,7 +565,7 @@ const ReviewPage = () => {
             localStorage.removeItem("labelAll");
           }
 
-          window.location.replace(`/#/projects/${ projectId }`);
+          window.location.replace(`/#/projects/${projectId}`);
           window.location.reload();
         }, 1000);
       }
@@ -598,13 +598,13 @@ const ReviewPage = () => {
       };
     }
     else if (
-      value === "delete-pair" 
+      value === "delete-pair"
     ) {
-      result  = resultValue.slice(0, resultValue.length - 1)
+      result = resultValue.slice(0, resultValue.length - 1)
     }
     else {
       resultValue
-    }   
+    }
     return !Array.isArray(result) ? [result] : result;
   };
 
@@ -791,12 +791,17 @@ const ReviewPage = () => {
           if (type === "MultipleLLMInstructionDrivenChat") {
             const allModelsInteractions = resp?.result?.[0]?.model_interactions;
             if (allModelsInteractions && Array.isArray(allModelsInteractions) && allModelsInteractions.length > 0) {
-              const interactions_length = allModelsInteractions[0]?.interaction_json?.length || 0;
+              const interactions_length = Math.max(
+                ...allModelsInteractions.map((m) => m?.interaction_json?.length || 0),
+                0
+              );
               let modifiedChatHistory = [];
               let globalModelFailure = false;
 
               for (let i = 0; i < interactions_length; i++) {
-                const prompt = allModelsInteractions[0]?.interaction_json[i]?.prompt;
+                const prompt = allModelsInteractions.find(
+                  (m) => m?.interaction_json?.[i]?.prompt
+                )?.interaction_json?.[i]?.prompt;
                 const modelOutputs = [];
                 let turnPromptOutputPairId = null;
                 let turnHasModelFailure = false;
@@ -808,15 +813,15 @@ const ReviewPage = () => {
                     if (!response_valid) {
                       turnHasModelFailure = true;
                     }
-                    if (modelIdx === 0) {
-                      turnPromptOutputPairId = interaction?.prompt_output_pair_id;
+                    if (interaction?.prompt_output_pair_id) {
+                      turnPromptOutputPairId = interaction.prompt_output_pair_id;
                     }
                     modelOutputs.push({
                       model_name: modelData?.model_name,
                       output: response_valid
                         ? formatResponse(interaction?.output)
                         : formatResponse(
-                          `${ modelData?.model_name } failed to generate a response`,
+                          `${modelData?.model_name} failed to generate a response`,
                         ),
                       status: response_valid ? "success" : "error",
                       prompt_output_pair_id: interaction?.prompt_output_pair_id,
@@ -1123,7 +1128,7 @@ const ReviewPage = () => {
     case "InstructionDrivenChat":
       componentToRender = (
         <InstructionDrivenChatPage
-          key={`annotations-${ annotations?.length }-${ annotations?.[0]?.id || "default"
+          key={`annotations-${annotations?.length}-${annotations?.[0]?.id || "default"
             }`}
           handleClick={handleReviewClick}
           chatHistory={chatHistory}
@@ -1145,7 +1150,7 @@ const ReviewPage = () => {
     case "MultipleLLMInstructionDrivenChat":
       componentToRender = (
         <MultipleLLMInstructionDrivenChat
-          key={`annotations-${ annotations?.length }-${ annotations?.[0]?.id || "default"
+          key={`annotations-${annotations?.length}-${annotations?.[0]?.id || "default"
             }`}
           handleClick={handleReviewClick}
           chatHistory={chatHistory}
@@ -1174,7 +1179,7 @@ const ReviewPage = () => {
         <ModelInteractionEvaluation
           key={
             annotations?.length > 0
-              ? `annotations-${ annotations[0]?.id }`
+              ? `annotations-${annotations[0]?.id}`
               : "annotations-default"
           }
           setCurrentInteraction={setCurrentInteraction}
@@ -1197,7 +1202,7 @@ const ReviewPage = () => {
         <PreferenceRanking
           key={
             annotations?.length > 0
-              ? `annotations-${ annotations[0]?.id }`
+              ? `annotations-${annotations[0]?.id}`
               : "annotations-default"
           }
           setCurrentInteraction={setCurrentInteraction}
@@ -1234,157 +1239,134 @@ const ReviewPage = () => {
       />
     );
   };
-return (
-  <>
-    {loading && <Spinner />}
-    <Grid container>
-      {renderSnackBar()}
-      
-      {/* Main Button Row - All buttons in one line */}
-      <Grid item xs={12}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, p: 1, flexWrap: 'wrap' }}>
-          {/* Back to Project Button */}
-          <Button
-            startIcon={<ArrowBackIcon />}
-            variant="contained"
-            color="primary"
-            size="small"
-            sx={{ 
-              minWidth: 'auto',
-              fontSize: '0.75rem',
-              px: 1.5,
-              py: 0.5
-            }}
-            onClick={() => {
-              if (typeof window !== "undefined") {
-                localStorage.removeItem("labelAll");
-              }
-              navigate(`/projects/${projectId}`);
-            }}
-          >
-            Back
-          </Button>
+  return (
+    <>
+      {loading && <Spinner />}
+      <Grid container>
+        {renderSnackBar()}
 
-          {/* Notes Button */}
-          <Button
-            endIcon={showNotes ? <ArrowRightIcon /> : <ArrowDropDown />}
-            variant="contained"
-            color={reviewtext.trim().length === 0 ? "primary" : "success"}
-            size="small"
-            onClick={handleCollapseClick}
-            sx={{ 
-              minWidth: 'auto',
-              fontSize: '0.75rem',
-              px: 1.5,
-              py: 0.5,
-              backgroundColor: reviewtext.trim().length === 0 ? "#bf360c" : "green",
-            }}
-          >
-            Notes {reviewtext.trim().length === 0 ? "" : "*"}
-          </Button>
-
-          {/* Info Button */}
-          <LightTooltip
-            title={
-              <div>
-                <div>
-                  {ProjectDetails?.conceal == false &&
-                  Array.isArray(assignedUsers)
-                    ? assignedUsers.join(", ")
-                    : assignedUsers || "No assigned users"}
-                </div>
-                <div
-                  style={{
-                    marginTop: "4px",
-                    fontWeight: "bold",
-                    textAlign: "center",
-                  }}
-                >
-                  {annotations[0]?.annotation_type == 1 &&
-                    `ANNOTATION ID: ${annotations[0]?.id}`}
-                  {annotations[0]?.annotation_type == 2 &&
-                    `REVIEW ID: ${annotations[0]?.id}`}
-                  {annotations[0]?.annotation_type == 3 &&
-                    `SUPERCHECK ID: ${annotations[0]?.id}`}
-                </div>
-              </div>
-            }
-          >
+        {/* Main Button Row - All buttons in one line */}
+        <Grid item xs={12}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, p: 1, flexWrap: 'wrap' }}>
+            {/* Back to Project Button */}
             <Button
+              startIcon={<ArrowBackIcon />}
+              variant="contained"
+              color="primary"
               size="small"
               sx={{
-                // px: { xs: 2, sm: 3, md: 4 },
-                // py: { xs: 1, sm: 1.5, md: 2 },
-                fontSize: { xs: "0.75rem", sm: "0.875rem", md: "1rem" },
-                minWidth: { xs: "70px", sm: "70px", md: "100px" },
+                minWidth: 'auto',
+                fontSize: '0.75rem',
+                px: 1.5,
+                py: 0.5
               }}
               onClick={() => {
                 if (typeof window !== "undefined") {
                   localStorage.removeItem("labelAll");
                 }
-
-                navigate(`/projects/${ projectId }`,  { replace : true, state: { fromBackToProject: true } });
-                //window.location.replace(`/#/projects/${projectId}`);
-                //window.location.reload();
+                navigate(`/projects/${projectId}`);
               }}
             >
-              <InfoOutlined sx={{ fontSize: '18px' }} />
+              Back
             </Button>
-          </LightTooltip>
 
-          {/* Draft Button */}
-          {!disableBtns && taskData?.review_user === userData?.id && (
-            <Tooltip title="Save task for later">
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={() =>
-                  handleReviewClick("draft", review.id, review.lead_time)
-                }
-                sx={{
-                  minWidth: 'auto',
-                  fontSize: '0.75rem',
-                  px: 1.5,
-                  py: 0.5,
-                  color: "black",
-                  border: "0px",
-                  backgroundColor: "#ffe0b2",
-                }}
-              >
-                Draft
-              </Button>
-            </Tooltip>
-          )}
-
-          {/* Next Button */}
-          <Tooltip title="Go to next task">
+            {/* Notes Button */}
             <Button
-              variant="outlined"
+              endIcon={showNotes ? <ArrowRightIcon /> : <ArrowDropDown />}
+              variant="contained"
+              color={reviewtext.trim().length === 0 ? "primary" : "success"}
               size="small"
-              onClick={() => onNextAnnotation("next", getNextTask?.id)}
+              onClick={handleCollapseClick}
               sx={{
                 minWidth: 'auto',
                 fontSize: '0.75rem',
                 px: 1.5,
                 py: 0.5,
-                color: "black",
-                border: "0px",
-                backgroundColor: "#ffe0b2",
+                backgroundColor: reviewtext.trim().length === 0 ? "#bf360c" : "green",
               }}
             >
-              Next
+              Notes {reviewtext.trim().length === 0 ? "" : "*"}
             </Button>
-          </Tooltip>
 
-          {/* Skip Button */}
-          {!disableSkip && taskData?.review_user === userData?.id && (
-            <Tooltip title="skip to next task">
+            {/* Info Button */}
+            <LightTooltip
+              title={
+                <div>
+                  <div>
+                    {ProjectDetails?.conceal == false &&
+                      Array.isArray(assignedUsers)
+                      ? assignedUsers.join(", ")
+                      : assignedUsers || "No assigned users"}
+                  </div>
+                  <div
+                    style={{
+                      marginTop: "4px",
+                      fontWeight: "bold",
+                      textAlign: "center",
+                    }}
+                  >
+                    {annotations[0]?.annotation_type == 1 &&
+                      `ANNOTATION ID: ${annotations[0]?.id}`}
+                    {annotations[0]?.annotation_type == 2 &&
+                      `REVIEW ID: ${annotations[0]?.id}`}
+                    {annotations[0]?.annotation_type == 3 &&
+                      `SUPERCHECK ID: ${annotations[0]?.id}`}
+                  </div>
+                </div>
+              }
+            >
+              <Button
+                size="small"
+                sx={{
+                  // px: { xs: 2, sm: 3, md: 4 },
+                  // py: { xs: 1, sm: 1.5, md: 2 },
+                  fontSize: { xs: "0.75rem", sm: "0.875rem", md: "1rem" },
+                  minWidth: { xs: "70px", sm: "70px", md: "100px" },
+                }}
+                onClick={() => {
+                  if (typeof window !== "undefined") {
+                    localStorage.removeItem("labelAll");
+                  }
+
+                  navigate(`/projects/${projectId}`, { replace: true, state: { fromBackToProject: true } });
+                  //window.location.replace(`/#/projects/${projectId}`);
+                  //window.location.reload();
+                }}
+              >
+                <InfoOutlined sx={{ fontSize: '18px' }} />
+              </Button>
+            </LightTooltip>
+
+            {/* Draft Button */}
+            {!disableBtns && taskData?.review_user === userData?.id && (
+              <Tooltip title="Save task for later">
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() =>
+                    handleReviewClick("draft", review.id, review.lead_time)
+                  }
+                  sx={{
+                    minWidth: 'auto',
+                    fontSize: '0.75rem',
+                    px: 1.5,
+                    py: 0.5,
+                    color: "black",
+                    border: "0px",
+                    backgroundColor: "#ffe0b2",
+                  }}
+                >
+                  Draft
+                </Button>
+              </Tooltip>
+            )}
+
+            {/* Next Button */}
+            <Tooltip title="Go to next task">
               <Button
                 variant="outlined"
                 size="small"
-                onClick={() =>
-                  handleReviewClick("skipped", review.id, review.lead_time)
-                }
+                onClick={() => onNextAnnotation("next", getNextTask?.id)}
                 sx={{
                   minWidth: 'auto',
                   fontSize: '0.75rem',
@@ -1395,82 +1377,131 @@ return (
                   backgroundColor: "#ffe0b2",
                 }}
               >
-                Skip
+                Next
               </Button>
             </Tooltip>
-          )}
 
-          {/* Clear Chats/Reset All Button */}
-          {ProjectDetails.project_type == "InstructionDrivenChat" ||
-          ProjectDetails?.project_type == "MultipleLLMInstructionDrivenChat" ? (
-            <Grid item>
-              {!disableSkip && taskData?.review_user === userData?.id && (
-                <Tooltip title="clear the entire chat history">
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() =>
-                      handleReviewClick("delete", review.id, review.lead_time)
-                    }
-                    sx={{
-                      minWidth: 'auto',
-                      fontSize: '0.75rem',
-                      px: 1.5,
-                      py: 0.5,
-                      color: "black",
-                      border: "0px",
-                      backgroundColor: "#ffe0b2",
-                    }}
-                  >
-                    Clear Chats
-                  </Button>
-                </Tooltip>
-              )}
-            </Grid>
-          ) : (
-            <Grid item>
-              {!disableSkip && taskData?.review_user === userData?.id && (
-                <Tooltip title="Reset the entire chat history">
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() =>
-                      handleReviewClick("delete", review.id, review.lead_time)
-                    }
-                    sx={{
-                      minWidth: 'auto',
-                      fontSize: '0.75rem',
-                      px: 1.5,
-                      py: 0.5,
-                      color: "black",
-                      border: "0px",
-                      backgroundColor: "#ffe0b2",
-                    }}
-                  >
-                    Reset All
-                  </Button>
-                </Tooltip>
-              )}
-            </Grid>
-          )}
-
-          {/* Revise Button */}
-          {!disableBtns &&
-            !disableButton &&
-            taskData?.review_user === userData?.id && (
-              <Tooltip title="Revise Annotation">
+            {/* Skip Button */}
+            {!disableSkip && taskData?.review_user === userData?.id && (
+              <Tooltip title="skip to next task">
                 <Button
                   variant="outlined"
                   size="small"
                   onClick={() =>
-                    handleReviewClick(
-                      "to_be_revised",
-                      review?.id,
-                      review?.lead_time,
-                      ProjectDetails?.project_type,
-                      review?.parent_annotation,
-                    )
+                    handleReviewClick("skipped", review.id, review.lead_time)
                   }
+                  sx={{
+                    minWidth: 'auto',
+                    fontSize: '0.75rem',
+                    px: 1.5,
+                    py: 0.5,
+                    color: "black",
+                    border: "0px",
+                    backgroundColor: "#ffe0b2",
+                  }}
+                >
+                  Skip
+                </Button>
+              </Tooltip>
+            )}
+
+            {/* Clear Chats/Reset All Button */}
+            {ProjectDetails.project_type == "InstructionDrivenChat" ||
+              ProjectDetails?.project_type == "MultipleLLMInstructionDrivenChat" ? (
+              <Grid item>
+                {!disableSkip && taskData?.review_user === userData?.id && (
+                  <Tooltip title="clear the entire chat history">
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={() =>
+                        handleReviewClick("delete", review.id, review.lead_time)
+                      }
+                      sx={{
+                        minWidth: 'auto',
+                        fontSize: '0.75rem',
+                        px: 1.5,
+                        py: 0.5,
+                        color: "black",
+                        border: "0px",
+                        backgroundColor: "#ffe0b2",
+                      }}
+                    >
+                      Clear Chats
+                    </Button>
+                  </Tooltip>
+                )}
+              </Grid>
+            ) : (
+              <Grid item>
+                {!disableSkip && taskData?.review_user === userData?.id && (
+                  <Tooltip title="Reset the entire chat history">
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={() =>
+                        handleReviewClick("delete", review.id, review.lead_time)
+                      }
+                      sx={{
+                        minWidth: 'auto',
+                        fontSize: '0.75rem',
+                        px: 1.5,
+                        py: 0.5,
+                        color: "black",
+                        border: "0px",
+                        backgroundColor: "#ffe0b2",
+                      }}
+                    >
+                      Reset All
+                    </Button>
+                  </Tooltip>
+                )}
+              </Grid>
+            )}
+
+            {/* Revise Button */}
+            {!disableBtns &&
+              !disableButton &&
+              taskData?.review_user === userData?.id && (
+                <Tooltip title="Revise Annotation">
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() =>
+                      handleReviewClick(
+                        "to_be_revised",
+                        review?.id,
+                        review?.lead_time,
+                        ProjectDetails?.project_type,
+                        review?.parent_annotation,
+                      )
+                    }
+                    sx={{
+                      minWidth: 'auto',
+                      fontSize: '0.75rem',
+                      px: 1.5,
+                      py: 0.5,
+                      color: "black",
+                      border: "0px",
+                      backgroundColor: "#ee6633",
+                    }}
+                  >
+                    Revise
+                  </Button>
+                </Tooltip>
+              )}
+
+            {/* Accept Button with Menu */}
+            {!disableBtns && taskData?.review_user === userData?.id && (
+              <Tooltip title="Accept Annotation">
+                <Button
+                  variant="outlined"
+                  size="small"
+                  disabled={isSubmitDisabled}
+                  id="accept-button"
+                  aria-controls={open ? "accept-menu" : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={open ? "true" : undefined}
                   sx={{
                     minWidth: 'auto',
                     fontSize: '0.75rem',
@@ -1480,145 +1511,119 @@ return (
                     border: "0px",
                     backgroundColor: "#ee6633",
                   }}
+                  onClick={handleClick}
+                  endIcon={<KeyboardArrowDownIcon />}
                 >
-                  Revise
+                  Accept
                 </Button>
               </Tooltip>
             )}
-
-          {/* Accept Button with Menu */}
-          {!disableBtns && taskData?.review_user === userData?.id && (
-            <Tooltip title="Accept Annotation">
-              <Button
-                variant="outlined"
-                size="small"
-                disabled={isSubmitDisabled}
-                id="accept-button"
-                aria-controls={open ? "accept-menu" : undefined}
-                aria-haspopup="true"
-                aria-expanded={open ? "true" : undefined}
-                sx={{
-                  minWidth: 'auto',
-                  fontSize: '0.75rem',
-                  px: 1.5,
-                  py: 0.5,
-                  color: "black",
-                  border: "0px",
-                  backgroundColor: "#ee6633",
+            <StyledMenu
+              id="accept-menu"
+              MenuListProps={{
+                "aria-labelledby": "accept-button",
+              }}
+              anchorEl={anchorEl}
+              open={open}
+              onClose={handleClose}
+            >
+              <MenuItem
+                onClick={() => {
+                  handleReviewClick(
+                    "accepted",
+                    review.id,
+                    AnnotationsTaskDetails[1]?.lead_time,
+                    ProjectDetails?.project_type,
+                    review?.parent_annotation,
+                  )
                 }}
-                onClick={handleClick}
-                endIcon={<KeyboardArrowDownIcon />}
+                disableRipple
               >
-                Accept
-              </Button>
-            </Tooltip>
-          )}
-          <StyledMenu
-            id="accept-menu"
-            MenuListProps={{
-              "aria-labelledby": "accept-button",
-            }}
-            anchorEl={anchorEl}
-            open={open}
-            onClose={handleClose}
-          >
-            <MenuItem
-              onClick={() => {
-                handleReviewClick(
-                  "accepted",
-                  review.id,
-                  AnnotationsTaskDetails[1]?.lead_time,
-                  ProjectDetails?.project_type,
-                  review?.parent_annotation,
-                )
-              }}
-              disableRipple
-            >
-              with No Changes
-            </MenuItem>
-            <MenuItem
-              onClick={() => {
-                handleReviewClick(
-                  "accepted_with_minor_changes",
-                  review.id,
-                  review.lead_time,
-                  ProjectDetails?.project_type,
-                  review?.parent_annotation,
-                )
-              }}
-              disableRipple
-            >
-              with Minor Changes
-            </MenuItem>
-            <MenuItem
-              onClick={() => {
-                handleReviewClick(
-                  "accepted_with_major_changes",
-                  review.id,
-                  review.lead_time,
-                  ProjectDetails?.project_type,
-                  review?.parent_annotation,
-                )
-              }}
-              disableRipple
-            >
-              with Major Changes
-            </MenuItem>
-          </StyledMenu>
-        </Box>
-      </Grid>
-
-      {/* Notes Section */}
-      <div
-        style={{
-          display: showNotes ? "block" : "none",
-          padding: "0 8px 8px 8px",
-          width: "100%"
-        }}
-      >
-        <ReactQuill
-          forwardedRef={annotationNotesRef}
-          modules={modules}
-          bounds={"#note"}
-          formats={formats}
-          placeholder="Annotation Notes"
-          readOnly={true}
-        ></ReactQuill>
-        <ReactQuill
-          forwardedRef={reviewNotesRef}
-          modules={modules}
-          bounds={"#note"}
-          formats={formats}
-          placeholder="Review Notes"
-          onChange={(_content, _delta, _source, editor) => {
-            setReviewNotesValue(JSON.stringify(editor.getContents()));
-            setreviewtext(editor.getText());
-          }}
-        ></ReactQuill>
-        <ReactQuill
-          forwardedRef={superCheckerNotesRef}
-          modules={modules}
-          bounds={"#note"}
-          formats={formats}
-          placeholder="SuperChecker Notes"
-          readOnly={true}
-        ></ReactQuill>
-      </div>
-
-      {filterMessage && (
-        <Alert severity="info" sx={{ mx: 1, mb: 1, fontSize: "0.75rem" }}>
-          {filterMessage}
-        </Alert>
-      )}
-      
-      {filteredReady == false && annotations.length > 0 ? (
-        <Grid item container>
-          {componentToRender}
+                with No Changes
+              </MenuItem>
+              <MenuItem
+                onClick={() => {
+                  handleReviewClick(
+                    "accepted_with_minor_changes",
+                    review.id,
+                    review.lead_time,
+                    ProjectDetails?.project_type,
+                    review?.parent_annotation,
+                  )
+                }}
+                disableRipple
+              >
+                with Minor Changes
+              </MenuItem>
+              <MenuItem
+                onClick={() => {
+                  handleReviewClick(
+                    "accepted_with_major_changes",
+                    review.id,
+                    review.lead_time,
+                    ProjectDetails?.project_type,
+                    review?.parent_annotation,
+                  )
+                }}
+                disableRipple
+              >
+                with Major Changes
+              </MenuItem>
+            </StyledMenu>
+          </Box>
         </Grid>
-      ) : null}
-    </Grid>
-  </>
-);
+
+        {/* Notes Section */}
+        <div
+          style={{
+            display: showNotes ? "block" : "none",
+            padding: "0 8px 8px 8px",
+            width: "100%"
+          }}
+        >
+          <ReactQuill
+            forwardedRef={annotationNotesRef}
+            modules={modules}
+            bounds={"#note"}
+            formats={formats}
+            placeholder="Annotation Notes"
+            readOnly={true}
+          ></ReactQuill>
+          <ReactQuill
+            forwardedRef={reviewNotesRef}
+            modules={modules}
+            bounds={"#note"}
+            formats={formats}
+            placeholder="Review Notes"
+            onChange={(_content, _delta, _source, editor) => {
+              setReviewNotesValue(JSON.stringify(editor.getContents()));
+              setreviewtext(editor.getText());
+            }}
+          ></ReactQuill>
+          <ReactQuill
+            forwardedRef={superCheckerNotesRef}
+            modules={modules}
+            bounds={"#note"}
+            formats={formats}
+            placeholder="SuperChecker Notes"
+            readOnly={true}
+          ></ReactQuill>
+        </div>
+
+        {filterMessage && (
+          <Alert severity="info" sx={{ mx: 1, mb: 1, fontSize: "0.75rem" }}>
+            {filterMessage}
+          </Alert>
+        )}
+
+        {filteredReady == false && annotations.length > 0 ? (
+          <Grid item container>
+            {componentToRender}
+          </Grid>
+        ) : null}
+      </Grid>
+    </>
+  );
 
 };
 export default ReviewPage;

--- a/src/app/ui/pages/chat/SuperCheckerPage.jsx
+++ b/src/app/ui/pages/chat/SuperCheckerPage.jsx
@@ -549,13 +549,13 @@ const SuperCheckerPage = () => {
       };
     }
     else if (
-      value === "delete-pair" 
+      value === "delete-pair"
     ) {
-      result  = resultValue.slice(0, resultValue.length - 1)
+      result = resultValue.slice(0, resultValue.length - 1)
     }
     else {
       resultValue
-    }   
+    }
     return !Array.isArray(result) ? [result] : result;
   };
 
@@ -655,14 +655,14 @@ const SuperCheckerPage = () => {
     const PatchAPIdata = {
       annotation_status:
         typeof window !== "undefined" &&
-        (value === "delete" || value === "delete-pair")
+          (value === "delete" || value === "delete-pair")
           ? localStorage.getItem("labellingMode")
           : value,
       supercheck_notes:
         typeof window !== "undefined"
           ? JSON.stringify(
-              superCheckerNotesRef?.current?.getEditor().getContents(),
-            )
+            superCheckerNotesRef?.current?.getEditor().getContents(),
+          )
           : null,
       lead_time:
         (new Date() - loadtime) / 1000 + Number(lead_time?.lead_time ?? 0),
@@ -674,7 +674,7 @@ const SuperCheckerPage = () => {
       result: buildResult(value, type, resultValue),
       task_id: taskId,
       auto_save:
-        value === "delete" || value === "delete-pair" 
+        value === "delete" || value === "delete-pair"
           ? true
           : false,
       interaction_llm: value === "delete" || value === "delete-pair",
@@ -738,12 +738,17 @@ const SuperCheckerPage = () => {
         if (type === "MultipleLLMInstructionDrivenChat") {
           const allModelsInteractions = resp?.result?.[0]?.model_interactions;
           if (allModelsInteractions && Array.isArray(allModelsInteractions) && allModelsInteractions.length > 0) {
-            const interactions_length = allModelsInteractions[0]?.interaction_json?.length || 0;
+            const interactions_length = Math.max(
+              ...allModelsInteractions.map((m) => m?.interaction_json?.length || 0),
+              0
+            );
             let modifiedChatHistory = [];
             let globalModelFailure = false;
 
             for (let i = 0; i < interactions_length; i++) {
-              const prompt = allModelsInteractions[0]?.interaction_json[i]?.prompt;
+              const prompt = allModelsInteractions.find(
+                (m) => m?.interaction_json?.[i]?.prompt
+              )?.interaction_json?.[i]?.prompt;
               const modelOutputs = [];
               let turnPromptOutputPairId = null;
               let turnHasModelFailure = false;
@@ -755,16 +760,16 @@ const SuperCheckerPage = () => {
                   if (!response_valid) {
                     turnHasModelFailure = true;
                   }
-                  if (modelIdx === 0) {
-                    turnPromptOutputPairId = interaction?.prompt_output_pair_id;
+                  if (interaction?.prompt_output_pair_id) {
+                    turnPromptOutputPairId = interaction.prompt_output_pair_id;
                   }
                   modelOutputs.push({
                     model_name: modelData?.model_name,
                     output: response_valid
                       ? formatResponse(interaction?.output)
                       : formatResponse(
-                          `${modelData?.model_name} failed to generate a response`,
-                        ),
+                        `${modelData?.model_name} failed to generate a response`,
+                      ),
                     status: response_valid ? "success" : "error",
                     prompt_output_pair_id: interaction?.prompt_output_pair_id,
                     output_error: response_valid
@@ -815,9 +820,9 @@ const SuperCheckerPage = () => {
             setChatHistory([...modifiedChatHistory]);
           } else {
             setChatHistory([]);
-            setIsModelFailing(false); 
+            setIsModelFailing(false);
           }
-        }else {
+        } else {
           let modifiedChatHistory = resp?.result.map((interaction) => {
             return {
               ...interaction,
@@ -837,21 +842,21 @@ const SuperCheckerPage = () => {
         }
         value === "delete"
           ? setSnackbarInfo({
-              open: true,
-              message: "Chat history has been cleared successfully!",
-              variant: "success",
-            })
+            open: true,
+            message: "Chat history has been cleared successfully!",
+            variant: "success",
+          })
           : value === "delete-pair"
             ? setSnackbarInfo({
-                open: true,
-                message: "Selected conversation is deleted",
-                variant: "success",
-              })
+              open: true,
+              message: "Selected conversation is deleted",
+              variant: "success",
+            })
             : setSnackbarInfo({
-                open: true,
-                message: resp?.message,
-                variant: "success",
-              });
+              open: true,
+              message: resp?.message,
+              variant: "success",
+            });
       } else {
         setAutoSave(true);
         setSnackbarInfo({
@@ -896,10 +901,10 @@ const SuperCheckerPage = () => {
           userAnnotation.result.length > 0
             ? [userAnnotation]
             : annotations.filter(
-                (annotation) =>
-                  annotation.id === userAnnotation.parent_annotation &&
-                  annotation.annotation_type === 2,
-              );
+              (annotation) =>
+                annotation.id === userAnnotation.parent_annotation &&
+                annotation.annotation_type === 2,
+            );
       } else if (
         ["validated", "validated_with_changes", "draft"].includes(
           userAnnotation.annotation_status,
@@ -987,9 +992,8 @@ const SuperCheckerPage = () => {
     case "InstructionDrivenChat":
       componentToRender = (
         <InstructionDrivenChatPage
-          key={`annotations-${annotations?.length}-${
-            annotations?.[0]?.id || "default"
-          }`}
+          key={`annotations-${annotations?.length}-${annotations?.[0]?.id || "default"
+            }`}
           handleClick={handleSuperCheckerClick}
           chatHistory={chatHistory}
           setChatHistory={setChatHistory}
@@ -1010,9 +1014,8 @@ const SuperCheckerPage = () => {
     case "MultipleLLMInstructionDrivenChat":
       componentToRender = (
         <MultipleLLMInstructionDrivenChat
-          key={`annotations-${annotations?.length}-${
-            annotations?.[0]?.id || "default"
-          }`}
+          key={`annotations-${annotations?.length}-${annotations?.[0]?.id || "default"
+            }`}
           handleClick={handleSuperCheckerClick}
           chatHistory={chatHistory}
           setChatHistory={setChatHistory}
@@ -1038,9 +1041,8 @@ const SuperCheckerPage = () => {
     case "ModelInteractionEvaluation":
       componentToRender = (
         <ModelInteractionEvaluation
-          key={`annotations-${annotations?.length}-${
-            annotations?.[0]?.id || "default"
-          }`}
+          key={`annotations-${annotations?.length}-${annotations?.[0]?.id || "default"
+            }`}
           setCurrentInteraction={setCurrentInteraction}
           currentInteraction={currentInteraction}
           interactions={interactions}
@@ -1059,9 +1061,8 @@ const SuperCheckerPage = () => {
     case "MultipleInteractionEvaluation":
       componentToRender = (
         <PreferenceRanking
-          key={`annotations-${annotations?.length}-${
-            annotations?.[0]?.id || "default"
-          }`}
+          key={`annotations-${annotations?.length}-${annotations?.[0]?.id || "default"
+            }`}
           setCurrentInteraction={setCurrentInteraction}
           currentInteraction={currentInteraction}
           interactions={interactions}
@@ -1104,164 +1105,137 @@ const SuperCheckerPage = () => {
       />
     );
   };
-return (
-  <>
-    {loading && <Spinner />}
-    <Grid container>
-      {renderSnackBar()}
-      
-      {/* Main Button Row - All buttons in one line */}
-      <Grid item xs={12}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, p: 1, flexWrap: 'wrap' }}>
-          {/* Back to Project Button */}
-          <Button
-            startIcon={<ArrowBackIcon />}
-            variant="contained"
-            color="primary"
-            size="small"
-            sx={{ 
-              minWidth: 'auto',
-              fontSize: '0.75rem',
-              px: 1.5,
-              py: 0.5
-            }}
-            onClick={() => {
-              if (typeof window !== "undefined") {
-                localStorage.removeItem("labelAll");
-              }
-              navigate(`/projects/${projectId}`);
-            }}
-          >
-            Back
-          </Button>
+  return (
+    <>
+      {loading && <Spinner />}
+      <Grid container>
+        {renderSnackBar()}
 
-          {/* Notes Button */}
-          <Button
-            endIcon={showNotes ? <ArrowRightIcon /> : <ArrowDropDown />}
-            variant="contained"
-            color={reviewtext.trim().length === 0 ? "primary" : "success"}
-            size="small"
-            onClick={handleCollapseClick}
-            sx={{ 
-              minWidth: 'auto',
-              fontSize: '0.75rem',
-              px: 1.5,
-              py: 0.5,
-              backgroundColor: reviewtext.trim().length === 0 ? "#bf360c" : "green",
-            }}
-          >
-            Notes {reviewtext.trim().length === 0 ? "" : "*"}
-          </Button>
-
-          {/* Info Button */}
-          <LightTooltip
-            title={
-              <div>
-                <div>
-                  {ProjectDetails?.conceal == false &&
-                  Array.isArray(assignedUsers)
-                    ? assignedUsers.join(", ")
-                    : assignedUsers || "No assigned users"}
-                </div>
-                <div
-                  style={{
-                    marginTop: "4px",
-                    fontWeight: "bold",
-                    textAlign: "center",
-                  }}
-                >
-                  {annotations[0]?.annotation_type == 1 &&
-                    `ANNOTATION ID: ${annotations[0]?.id}`}
-                  {annotations[0]?.annotation_type == 2 &&
-                    `REVIEW ID: ${annotations[0]?.id}`}
-                  {annotations[0]?.annotation_type == 3 &&
-                    `SUPERCHECK ID: ${annotations[0]?.id}`}
-                </div>
-              </div>
-            }
-          >
+        {/* Main Button Row - All buttons in one line */}
+        <Grid item xs={12}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, p: 1, flexWrap: 'wrap' }}>
+            {/* Back to Project Button */}
             <Button
+              startIcon={<ArrowBackIcon />}
+              variant="contained"
+              color="primary"
               size="small"
               sx={{
-                // px: { xs: 2, sm: 3, md: 4 },
-                // py: { xs: 1, sm: 1.5, md: 2 },
-                fontSize: { xs: "0.75rem", sm: "0.875rem", md: "1rem" },
-                minWidth: { xs: "70px", sm: "70px", md: "100px" },
+                minWidth: 'auto',
+                fontSize: '0.75rem',
+                px: 1.5,
+                py: 0.5
               }}
               onClick={() => {
                 if (typeof window !== "undefined") {
                   localStorage.removeItem("labelAll");
                 }
-                navigate(`/projects/${projectId}`,  { replace : true, state: { fromBackToProject: true } });
-                //window.location.replace(`/#/projects/${projectId}`);
-                //window.location.reload();
+                navigate(`/projects/${projectId}`);
               }}
             >
-              <InfoOutlined sx={{ fontSize: '18px' }} />
+              Back
             </Button>
-          </LightTooltip>
 
-          {/* Draft Button */}
-          {taskData?.super_check_user === userData?.id && (
-            <Tooltip title="Save task for later">
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={() =>
-                  handleSuperCheckerClick(
-                    "draft",
-                    SuperChecker.id,
-                    SuperChecker.lead_time,
-                  )
-                }
-                sx={{
-                  minWidth: 'auto',
-                  fontSize: '0.75rem',
-                  px: 1.5,
-                  py: 0.5,
-                  color: "black",
-                  border: "0px",
-                  backgroundColor: "#ffe0b2",
-                }}
-              >
-                Draft
-              </Button>
-            </Tooltip>
-          )}
-
-          {/* Next Button */}
-          <Tooltip title="Go to next task">
+            {/* Notes Button */}
             <Button
-              variant="outlined"
+              endIcon={showNotes ? <ArrowRightIcon /> : <ArrowDropDown />}
+              variant="contained"
+              color={reviewtext.trim().length === 0 ? "primary" : "success"}
               size="small"
-              onClick={() => onNextAnnotation("next", getNextTask?.id)}
+              onClick={handleCollapseClick}
               sx={{
                 minWidth: 'auto',
                 fontSize: '0.75rem',
                 px: 1.5,
                 py: 0.5,
-                color: "black",
-                border: "0px",
-                backgroundColor: "#ffe0b2",
+                backgroundColor: reviewtext.trim().length === 0 ? "#bf360c" : "green",
               }}
             >
-              Next
+              Notes {reviewtext.trim().length === 0 ? "" : "*"}
             </Button>
-          </Tooltip>
 
-          {/* Skip Button */}
-          {!disableSkip && taskData?.super_check_user === userData?.id && (
-            <Tooltip title="skip to next task">
+            {/* Info Button */}
+            <LightTooltip
+              title={
+                <div>
+                  <div>
+                    {ProjectDetails?.conceal == false &&
+                      Array.isArray(assignedUsers)
+                      ? assignedUsers.join(", ")
+                      : assignedUsers || "No assigned users"}
+                  </div>
+                  <div
+                    style={{
+                      marginTop: "4px",
+                      fontWeight: "bold",
+                      textAlign: "center",
+                    }}
+                  >
+                    {annotations[0]?.annotation_type == 1 &&
+                      `ANNOTATION ID: ${annotations[0]?.id}`}
+                    {annotations[0]?.annotation_type == 2 &&
+                      `REVIEW ID: ${annotations[0]?.id}`}
+                    {annotations[0]?.annotation_type == 3 &&
+                      `SUPERCHECK ID: ${annotations[0]?.id}`}
+                  </div>
+                </div>
+              }
+            >
+              <Button
+                size="small"
+                sx={{
+                  // px: { xs: 2, sm: 3, md: 4 },
+                  // py: { xs: 1, sm: 1.5, md: 2 },
+                  fontSize: { xs: "0.75rem", sm: "0.875rem", md: "1rem" },
+                  minWidth: { xs: "70px", sm: "70px", md: "100px" },
+                }}
+                onClick={() => {
+                  if (typeof window !== "undefined") {
+                    localStorage.removeItem("labelAll");
+                  }
+                  navigate(`/projects/${projectId}`, { replace: true, state: { fromBackToProject: true } });
+                  //window.location.replace(`/#/projects/${projectId}`);
+                  //window.location.reload();
+                }}
+              >
+                <InfoOutlined sx={{ fontSize: '18px' }} />
+              </Button>
+            </LightTooltip>
+
+            {/* Draft Button */}
+            {taskData?.super_check_user === userData?.id && (
+              <Tooltip title="Save task for later">
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() =>
+                    handleSuperCheckerClick(
+                      "draft",
+                      SuperChecker.id,
+                      SuperChecker.lead_time,
+                    )
+                  }
+                  sx={{
+                    minWidth: 'auto',
+                    fontSize: '0.75rem',
+                    px: 1.5,
+                    py: 0.5,
+                    color: "black",
+                    border: "0px",
+                    backgroundColor: "#ffe0b2",
+                  }}
+                >
+                  Draft
+                </Button>
+              </Tooltip>
+            )}
+
+            {/* Next Button */}
+            <Tooltip title="Go to next task">
               <Button
                 variant="outlined"
                 size="small"
-                onClick={() =>
-                  handleSuperCheckerClick(
-                    "skipped",
-                    SuperChecker.id,
-                    SuperChecker.lead_time,
-                  )
-                }
+                onClick={() => onNextAnnotation("next", getNextTask?.id)}
                 sx={{
                   minWidth: 'auto',
                   fontSize: '0.75rem',
@@ -1272,178 +1246,205 @@ return (
                   backgroundColor: "#ffe0b2",
                 }}
               >
-                Skip
+                Next
               </Button>
             </Tooltip>
-          )}
 
-          {/* Clear Chats Button */}
-          {!disableSkip && taskData?.super_check_user === userData?.id && (
-            <Tooltip title="clear the entire chat history">
-              <Button
-                variant="outlined"
-                size="small"
+            {/* Skip Button */}
+            {!disableSkip && taskData?.super_check_user === userData?.id && (
+              <Tooltip title="skip to next task">
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() =>
+                    handleSuperCheckerClick(
+                      "skipped",
+                      SuperChecker.id,
+                      SuperChecker.lead_time,
+                    )
+                  }
+                  sx={{
+                    minWidth: 'auto',
+                    fontSize: '0.75rem',
+                    px: 1.5,
+                    py: 0.5,
+                    color: "black",
+                    border: "0px",
+                    backgroundColor: "#ffe0b2",
+                  }}
+                >
+                  Skip
+                </Button>
+              </Tooltip>
+            )}
+
+            {/* Clear Chats Button */}
+            {!disableSkip && taskData?.super_check_user === userData?.id && (
+              <Tooltip title="clear the entire chat history">
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() =>
+                    handleSuperCheckerClick(
+                      "delete",
+                      SuperChecker.id,
+                      SuperChecker.lead_time,
+                    )
+                  }
+                  sx={{
+                    minWidth: 'auto',
+                    fontSize: '0.75rem',
+                    px: 1.5,
+                    py: 0.5,
+                    color: "black",
+                    border: "0px",
+                    backgroundColor: "#ffe0b2",
+                  }}
+                >
+                  Clear Chats
+                </Button>
+              </Tooltip>
+            )}
+
+            {/* Reject Button */}
+            {taskData?.super_check_user === userData?.id && (
+              <Tooltip title="Reject">
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() =>
+                    handleSuperCheckerClick(
+                      "rejected",
+                      SuperChecker.id,
+                      SuperChecker.lead_time,
+                      "",
+                      SuperChecker.parent_annotation,
+                    )
+                  }
+                  disabled={
+                    ProjectData.revision_loop_count >
+                      taskData?.revision_loop_count?.super_check_count
+                      ? false
+                      : true
+                  }
+                  sx={{
+                    minWidth: 'auto',
+                    fontSize: '0.75rem',
+                    px: 1.5,
+                    py: 0.5,
+                    color: "black",
+                    border: "0px",
+                    backgroundColor: "#ee6633",
+                  }}
+                >
+                  Reject
+                </Button>
+              </Tooltip>
+            )}
+
+            {/* Validate Button with Menu */}
+            {taskData?.super_check_user === userData?.id && (
+              <Tooltip title="Validate">
+                <Button
+                  variant="outlined"
+                  size="small"
+                  disabled={isSubmitDisabled}
+                  id="accept-button"
+                  aria-controls={open ? "accept-menu" : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={open ? "true" : undefined}
+                  sx={{
+                    minWidth: 'auto',
+                    fontSize: '0.75rem',
+                    px: 1.5,
+                    py: 0.5,
+                    color: "black",
+                    border: "0px",
+                    backgroundColor: "#ee6633",
+                  }}
+                  onClick={handleClick}
+                  endIcon={<KeyboardArrowDownIcon />}
+                >
+                  Validate
+                </Button>
+              </Tooltip>
+            )}
+            <StyledMenu
+              id="accept-menu"
+              MenuListProps={{
+                "aria-labelledby": "accept-button",
+              }}
+              anchorEl={anchorEl}
+              open={open}
+              onClose={handleClose}
+            >
+              <MenuItem
                 onClick={() =>
                   handleSuperCheckerClick(
-                    "delete",
-                    SuperChecker.id,
-                    SuperChecker.lead_time,
-                  )
-                }
-                sx={{
-                  minWidth: 'auto',
-                  fontSize: '0.75rem',
-                  px: 1.5,
-                  py: 0.5,
-                  color: "black",
-                  border: "0px",
-                  backgroundColor: "#ffe0b2",
-                }}
-              >
-                Clear Chats
-              </Button>
-            </Tooltip>
-          )}
-
-          {/* Reject Button */}
-          {taskData?.super_check_user === userData?.id && (
-            <Tooltip title="Reject">
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={() =>
-                  handleSuperCheckerClick(
-                    "rejected",
+                    "validated",
                     SuperChecker.id,
                     SuperChecker.lead_time,
                     "",
                     SuperChecker.parent_annotation,
                   )
                 }
-                disabled={
-                  ProjectData.revision_loop_count >
-                  taskData?.revision_loop_count?.super_check_count
-                    ? false
-                    : true
+                disableRipple
+              >
+                Validated No Changes
+              </MenuItem>
+              <MenuItem
+                onClick={() =>
+                  handleSuperCheckerClick(
+                    "validated_with_changes",
+                    SuperChecker.id,
+                    SuperChecker.lead_time,
+                    "",
+                    SuperChecker.parent_annotation,
+                  )
                 }
-                sx={{
-                  minWidth: 'auto',
-                  fontSize: '0.75rem',
-                  px: 1.5,
-                  py: 0.5,
-                  color: "black",
-                  border: "0px",
-                  backgroundColor: "#ee6633",
-                }}
+                disableRipple
               >
-                Reject
-              </Button>
-            </Tooltip>
-          )}
+                Validated with Changes
+              </MenuItem>
+            </StyledMenu>
+          </Box>
+        </Grid>
 
-          {/* Validate Button with Menu */}
-          {taskData?.super_check_user === userData?.id && (
-            <Tooltip title="Validate">
-              <Button
-                variant="outlined"
-                size="small"
-                disabled={isSubmitDisabled}
-                id="accept-button"
-                aria-controls={open ? "accept-menu" : undefined}
-                aria-haspopup="true"
-                aria-expanded={open ? "true" : undefined}
-                sx={{
-                  minWidth: 'auto',
-                  fontSize: '0.75rem',
-                  px: 1.5,
-                  py: 0.5,
-                  color: "black",
-                  border: "0px",
-                  backgroundColor: "#ee6633",
-                }}
-                onClick={handleClick}
-                endIcon={<KeyboardArrowDownIcon />}
-              >
-                Validate
-              </Button>
-            </Tooltip>
-          )}
-          <StyledMenu
-            id="accept-menu"
-            MenuListProps={{
-              "aria-labelledby": "accept-button",
-            }}
-            anchorEl={anchorEl}
-            open={open}
-            onClose={handleClose}
-          >
-            <MenuItem
-              onClick={() =>
-                handleSuperCheckerClick(
-                  "validated",
-                  SuperChecker.id,
-                  SuperChecker.lead_time,
-                  "",
-                  SuperChecker.parent_annotation,
-                )
-              }
-              disableRipple
-            >
-              Validated No Changes
-            </MenuItem>
-            <MenuItem
-              onClick={() =>
-                handleSuperCheckerClick(
-                  "validated_with_changes",
-                  SuperChecker.id,
-                  SuperChecker.lead_time,
-                  "",
-                  SuperChecker.parent_annotation,
-                )
-              }
-              disableRipple
-            >
-              Validated with Changes
-            </MenuItem>
-          </StyledMenu>
-        </Box>
-      </Grid>
-
-      {/* Notes Section */}
-      <div
-        style={{
-          display: showNotes ? "block" : "none",
-          padding: "0 8px 8px 8px",
-          width: "100%"
-        }}
-      >
-        <ReactQuill
-          forwardedRef={reviewNotesRef}
-          modules={modules}
-          formats={formats}
-          bounds={"#note"}
-          placeholder="Review Notes"
-          style={{ marginBottom: "1%", minHeight: "2rem" }}
-          readOnly={true}
-        ></ReactQuill>
-        <ReactQuill
-          forwardedRef={superCheckerNotesRef}
-          modules={modules}
-          formats={formats}
-          bounds={"#note"}
-          placeholder="Superchecker Notes"
-          onChange={(_content, _delta, _source, editor) => {
-            setSuperCheckerNotesValue(JSON.stringify(editor.getContents()));
-            setsupercheckertext(editor.getText());
+        {/* Notes Section */}
+        <div
+          style={{
+            display: showNotes ? "block" : "none",
+            padding: "0 8px 8px 8px",
+            width: "100%"
           }}
-        ></ReactQuill>
-      </div>
+        >
+          <ReactQuill
+            forwardedRef={reviewNotesRef}
+            modules={modules}
+            formats={formats}
+            bounds={"#note"}
+            placeholder="Review Notes"
+            style={{ marginBottom: "1%", minHeight: "2rem" }}
+            readOnly={true}
+          ></ReactQuill>
+          <ReactQuill
+            forwardedRef={superCheckerNotesRef}
+            modules={modules}
+            formats={formats}
+            bounds={"#note"}
+            placeholder="Superchecker Notes"
+            onChange={(_content, _delta, _source, editor) => {
+              setSuperCheckerNotesValue(JSON.stringify(editor.getContents()));
+              setsupercheckertext(editor.getText());
+            }}
+          ></ReactQuill>
+        </div>
 
-      {/* Revision Loop Count Messages */}
-      {ProjectDetails.revision_loop_count >
-      taskData?.revision_loop_count?.super_check_count
-        ? false
-        : true && (
+        {/* Revision Loop Count Messages */}
+        {ProjectDetails.revision_loop_count >
+          taskData?.revision_loop_count?.super_check_count
+          ? false
+          : true && (
             <div
               style={{
                 textAlign: "left",
@@ -1470,48 +1471,48 @@ return (
             </div>
           )}
 
-      {ProjectDetails.revision_loop_count -
-        taskData?.revision_loop_count?.super_check_count !==
-        0 && (
-        <div
-          style={{
-            textAlign: "left",
-            marginLeft: "8px",
-            marginTop: "8px",
-          }}
-        >
-          <Typography
-            variant="body"
-            color="#f5222d"
-            sx={{
-              fontSize: {
-                xs: "14px",
-                md: "16px",
-                lg: "18px",
-                xl: "20px",
-              },
-            }}
-          >
-            Note: This task can be rejected{" "}
-            {ProjectDetails.revision_loop_count -
-              taskData?.revision_loop_count?.super_check_count}{" "}
-            more times.
-          </Typography>
-        </div>
-      )}
+        {ProjectDetails.revision_loop_count -
+          taskData?.revision_loop_count?.super_check_count !==
+          0 && (
+            <div
+              style={{
+                textAlign: "left",
+                marginLeft: "8px",
+                marginTop: "8px",
+              }}
+            >
+              <Typography
+                variant="body"
+                color="#f5222d"
+                sx={{
+                  fontSize: {
+                    xs: "14px",
+                    md: "16px",
+                    lg: "18px",
+                    xl: "20px",
+                  },
+                }}
+              >
+                Note: This task can be rejected{" "}
+                {ProjectDetails.revision_loop_count -
+                  taskData?.revision_loop_count?.super_check_count}{" "}
+                more times.
+              </Typography>
+            </div>
+          )}
 
-      {filterMessage && (
-        <Alert severity="info" sx={{ mx: 1, mb: 1, fontSize: "0.75rem" }}>
-          {filterMessage}
-        </Alert>
-      )}
-      
-      <Grid item container>
-        {componentToRender}
+        {filterMessage && (
+          <Alert severity="info" sx={{ mx: 1, mb: 1, fontSize: "0.75rem" }}>
+            {filterMessage}
+          </Alert>
+        )}
+
+        <Grid item container>
+          {componentToRender}
+        </Grid>
       </Grid>
-    </Grid>
-  </>
-);
+    </>
+  );
 };
 
 export default SuperCheckerPage;

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -158,6 +158,13 @@ const MultipleLLMInstructionDrivenChat = ({
 
   const [loadtime, setloadtime] = useState(new Date());
   const { streamMultiModelResponse, abortStream } = useStreamingLLM();
+  const latestAnnotationResultRef = useRef({ eval_form: [], model_interactions: [] });
+
+  useEffect(() => {
+    if (annotation?.[0]?.result?.[0]) {
+      latestAnnotationResultRef.current = annotation[0].result[0];
+    }
+  }, [annotation]);
 
   useEffect(() => {
     if (setIsModelStreaming) {
@@ -369,12 +376,15 @@ const MultipleLLMInstructionDrivenChat = ({
     ) {
       const allModelsInteractions =
         annotation[0].result[0].model_interactions;
-      const interactions_length =
-        allModelsInteractions[0]?.interaction_json?.length || 0;
+      const interactions_length = Math.max(
+        ...allModelsInteractions.map((m) => m?.interaction_json?.length || 0),
+        0
+      );
       console.log("lead", allModelsInteractions);
       for (let i = 0; i < interactions_length; i++) {
-        const prompt =
-          allModelsInteractions[0]?.interaction_json[i]?.prompt;
+        const prompt = allModelsInteractions.find(
+          (m) => m?.interaction_json?.[i]?.prompt
+        )?.interaction_json?.[i]?.prompt;
 
         const modelOutputs = [];
         let turnPromptOutputPairId = null;
@@ -386,8 +396,8 @@ const MultipleLLMInstructionDrivenChat = ({
             if (!response_valid) {
               setIsModelFailing(true);
             }
-            if (modelIdx === 0) {
-              turnPromptOutputPairId = interaction?.prompt_output_pair_id;
+            if (interaction?.prompt_output_pair_id) {
+              turnPromptOutputPairId = interaction.prompt_output_pair_id;
             }
 
             modelOutputs.push({
@@ -438,15 +448,22 @@ const MultipleLLMInstructionDrivenChat = ({
           });
         }
       }
+      let skipChatHistoryUpdate = false;
       const localInProgress = localStorage.getItem(`in_progress_chat_${taskId}`);
       if (localInProgress) {
         try {
           const parsedLocal = JSON.parse(localInProgress);
           if (parsedLocal && parsedLocal.length > modifiedChatHistory.length) {
-            const missingTurns = parsedLocal.slice(modifiedChatHistory.length);
-            modifiedChatHistory = [...modifiedChatHistory, ...missingTurns];
+            skipChatHistoryUpdate = true;
             setIsStreaming(true);
             setIsPolling(true);
+            setChatHistory((prev) => {
+              if (prev.length < parsedLocal.length) {
+                const missingTurns = parsedLocal.slice(modifiedChatHistory.length);
+                return [...modifiedChatHistory, ...missingTurns];
+              }
+              return prev;
+            });
           } else if (parsedLocal && parsedLocal.length <= modifiedChatHistory.length) {
             localStorage.removeItem(`in_progress_chat_${taskId}`);
             setIsStreaming(false);
@@ -456,9 +473,14 @@ const MultipleLLMInstructionDrivenChat = ({
         } catch (e) {
           console.error(e);
         }
+      } else {
+        setIsPolling(false);
+        setPollingCount(0);
       }
 
-      setChatHistory(modifiedChatHistory);
+      if (!skipChatHistoryUpdate) {
+        setChatHistory(modifiedChatHistory);
+      }
     } else {
       setChatHistory([]);
     }
@@ -636,144 +658,152 @@ const MultipleLLMInstructionDrivenChat = ({
           body.parentannotation = id?.parent_annotation;
         }
 
-      try {
-        // Wait for the stream to complete
-        const streamedTexts = await streamPromise;
+        try {
+          // Wait for the stream to complete
+          const streamedTexts = await streamPromise;
 
-        if (streamedTexts) {
-          const currentAnnotationResult = annotation?.[0]?.result?.[0] || { eval_form: [], model_interactions: [] };
-          // Deep clone model_interactions
-          const newModelInteractions = JSON.parse(JSON.stringify(currentAnnotationResult.model_interactions || []));
-          
-          Object.entries(streamedTexts).forEach(([modelName, text]) => {
-            let modelEntry = newModelInteractions.find(m => m.model_name === modelName || m.model_id === modelName);
-            if (!modelEntry) {
-              modelEntry = { model_name: modelName, model_id: modelName, interaction_json: [] };
-              newModelInteractions.push(modelEntry);
-            }
-            modelEntry.interaction_json.push({
-              prompt: currentPrompt,
-              output: text,
-              preferred_response: false,
-              prompt_output_pair_id: body.prompt_output_pair_id
+          if (streamedTexts) {
+            const currentAnnotationResult = latestAnnotationResultRef.current;
+            // Deep clone model_interactions
+            const newModelInteractions = JSON.parse(JSON.stringify(currentAnnotationResult.model_interactions || []));
+
+            Object.entries(streamedTexts).forEach(([modelName, text]) => {
+              let modelEntry = newModelInteractions.find(m => m.model_name === modelName || m.model_id === modelName);
+              if (!modelEntry) {
+                modelEntry = { model_name: modelName, model_id: modelName, interaction_json: [] };
+                newModelInteractions.push(modelEntry);
+              }
+              modelEntry.interaction_json.push({
+                prompt: currentPrompt,
+                output: text,
+                preferred_response: false,
+                prompt_output_pair_id: body.prompt_output_pair_id
+              });
             });
-          });
 
-          body.result = [{
-            eval_form: currentAnnotationResult.eval_form,
-            model_interactions: newModelInteractions
-          }];
+            body.result = [{
+              eval_form: currentAnnotationResult.eval_form,
+              model_interactions: newModelInteractions
+            }];
 
-          const AnnotationObj = new PatchAnnotationAPI(id?.id, body);
-          const res = await fetch(AnnotationObj.apiEndPoint(), {
-            method: "PATCH",
-            body: JSON.stringify(AnnotationObj.getBody()),
-            headers: AnnotationObj.getHeaders().headers,
-          });
-          const data = await res.json();
+            const AnnotationObj = new PatchAnnotationAPI(id?.id, body);
+            const res = await fetch(AnnotationObj.apiEndPoint(), {
+              method: "PATCH",
+              body: JSON.stringify(AnnotationObj.getBody()),
+              headers: AnnotationObj.getHeaders().headers,
+            });
+            const data = await res.json();
 
-          let errorMessage = null;
-          if (data && data.output) {
-            for (const [modelName, modelResponse] of Object.entries(data.output)) {
-              if (modelResponse?.error) {
-                errorMessage = `${modelName} error: ${modelResponse.error}`;
-                break;
+            let errorMessage = null;
+            if (data && data.output) {
+              for (const [modelName, modelResponse] of Object.entries(data.output)) {
+                if (modelResponse?.error) {
+                  errorMessage = `${modelName} error: ${modelResponse.error}`;
+                  break;
+                }
               }
             }
-          }
 
-          if (!res.ok) {
-            setChatHistory((prev) => prev.slice(0, -1));
-            setSnackbarInfo({
-              open: true,
-              message: data?.message || errorMessage || "An error occurred while saving the annotation.",
-              variant: "error",
-            });
-            return;
-          }
+            if (!res.ok) {
+              setChatHistory((prev) => prev.slice(0, -1));
+              setSnackbarInfo({
+                open: true,
+                message: data?.message || errorMessage || "An error occurred while saving the annotation.",
+                variant: "error",
+              });
+              return;
+            }
 
-          if (errorMessage) {
-            setSnackbarInfo({
-              open: true,
-              message: errorMessage,
-              variant: "error",
-            });
-          }
+            if (errorMessage) {
+              setSnackbarInfo({
+                open: true,
+                message: errorMessage,
+                variant: "error",
+              });
+            }
 
-          // Once PATCH completes, sync the full result from DB (source of truth)
-          if (data && data.result && data.result.length > 0 && data.result[0].model_interactions) {
-            const allModelsInteractions = data.result[0].model_interactions;
-            const interactions_length =
-              allModelsInteractions[0]?.interaction_json?.length || 0;
-            let modifiedChatHistory = [];
+            // Once PATCH completes, sync the full result from DB (source of truth)
+            if (data && data.result && data.result.length > 0 && data.result[0].model_interactions) {
+              const allModelsInteractions = data.result[0].model_interactions;
+              const interactions_length = Math.max(
+                ...allModelsInteractions.map((m) => m?.interaction_json?.length || 0),
+                0
+              );
+              let modifiedChatHistory = [];
 
-            for (let i = 0; i < interactions_length; i++) {
-              const prompt = allModelsInteractions[0]?.interaction_json[i]?.prompt;
-              const modelOutputs = [];
-              let turnPromptOutputPairId = null;
+              for (let i = 0; i < interactions_length; i++) {
+                const prompt = allModelsInteractions.find(
+                  (m) => m?.interaction_json?.[i]?.prompt
+                )?.interaction_json?.[i]?.prompt;
+                const modelOutputs = [];
+                let turnPromptOutputPairId = null;
 
-              allModelsInteractions.forEach((modelData, modelIdx) => {
-                const interaction = modelData?.interaction_json?.[i];
-                if (interaction) {
-                  const response_valid = isString(interaction?.output);
-                  if (!response_valid) {
-                    setIsModelFailing(true);
+                allModelsInteractions.forEach((modelData, modelIdx) => {
+                  const interaction = modelData?.interaction_json?.[i];
+                  if (interaction) {
+                    const response_valid = isString(interaction?.output);
+                    if (!response_valid) {
+                      setIsModelFailing(true);
+                    }
+                    if (interaction?.prompt_output_pair_id) {
+                      turnPromptOutputPairId = interaction.prompt_output_pair_id;
+                    }
+                    modelOutputs.push({
+                      model_id: modelData?.model_id || modelData?.model_name,
+                      model_name: modelData?.model_name || `Model ${modelIdx + 1}`,
+                      output: response_valid
+                        ? formatResponse(interaction?.output)
+                        : formatResponse(
+                          `${modelData?.model_name || `Model ${modelIdx + 1}`} failed to generate a response`,
+                        ),
+                      status: response_valid ? "success" : "error",
+                      prompt_output_pair_id: interaction?.prompt_output_pair_id,
+                      output_error: response_valid
+                        ? null
+                        : JSON.stringify(interaction?.output),
+                    });
                   }
-                  if (modelIdx === 0) {
-                    turnPromptOutputPairId = interaction?.prompt_output_pair_id;
+                });
+
+                if (turnPromptOutputPairId) {
+                  const eval_form = (
+                    Array.isArray(data?.result[0]?.eval_form)
+                      ? data.result[0].eval_form
+                      : []
+                  ).find(
+                    (item) => item.prompt_output_pair_id === turnPromptOutputPairId,
+                  );
+                  if (eval_form) {
+                    setEvalFormResponse((prev) => ({
+                      ...prev,
+                      [turnPromptOutputPairId]: eval_form,
+                    }));
                   }
-                  modelOutputs.push({
-                    model_id: modelData?.model_id || modelData?.model_name,
-                    model_name: modelData?.model_name || `Model ${modelIdx + 1}`,
-                    output: response_valid
-                      ? formatResponse(interaction?.output)
-                      : formatResponse(
-                        `${modelData?.model_name || `Model ${modelIdx + 1}`} failed to generate a response`,
-                      ),
-                    status: response_valid ? "success" : "error",
-                    prompt_output_pair_id: interaction?.prompt_output_pair_id,
-                    output_error: response_valid
-                      ? null
-                      : JSON.stringify(interaction?.output),
+                }
+
+                if (prompt !== undefined && modelOutputs.length > 0) {
+                  modifiedChatHistory.push({
+                    prompt: prompt,
+                    output: modelOutputs,
+                    prompt_output_pair_id: turnPromptOutputPairId,
                   });
                 }
-              });
-
-              if (turnPromptOutputPairId) {
-                const eval_form = (
-                  Array.isArray(data?.result[0]?.eval_form)
-                    ? data.result[0].eval_form
-                    : []
-                ).find(
-                  (item) => item.prompt_output_pair_id === turnPromptOutputPairId,
-                );
-                if (eval_form) {
-                  setEvalFormResponse((prev) => ({
-                    ...prev,
-                    [turnPromptOutputPairId]: eval_form,
-                  }));
-                }
               }
-
-              if (prompt !== undefined && modelOutputs.length > 0) {
-                modifiedChatHistory.push({
-                  prompt: prompt,
-                  output: modelOutputs,
-                  prompt_output_pair_id: turnPromptOutputPairId,
-                });
-              }
+              latestAnnotationResultRef.current = data.result[0];
+              setChatHistory([...modifiedChatHistory]);
+              dispatch(fetchAnnotationsTask(taskId));
             }
-            setChatHistory([...modifiedChatHistory]);
           }
+        } catch (error) {
+          console.error("Error in multi-model chat save/stream operation:", error);
+        } finally {
+          setChatLoading(false);
+          setIsStreaming(false);
+          setIsPolling(false);
+          setPollingCount(0);
+          setLoading(false);
+          localStorage.removeItem(`in_progress_chat_${taskId}`);
         }
-      } catch (error) {
-        console.error("Error in multi-model chat save/stream operation:", error);
-      } finally {
-        setChatLoading(false);
-        setIsStreaming(false);
-        setLoading(false);
-        localStorage.removeItem(`in_progress_chat_${taskId}`);
-      }
 
         setVisibleMessages((prev) => ({
           ...prev,
@@ -895,11 +925,15 @@ const MultipleLLMInstructionDrivenChat = ({
 
         if (data && data.result && data.result.length > 0 && data.result[0].model_interactions && Array.isArray(data.result[0].model_interactions) && data.result[0].model_interactions.length > 0) {
           const allModelsInteractions = data.result[0].model_interactions;
-          const interactions_length =
-            allModelsInteractions[0]?.interaction_json?.length || 0;
+          const interactions_length = Math.max(
+            ...allModelsInteractions.map((m) => m?.interaction_json?.length || 0),
+            0
+          );
 
           for (let i = 0; i < interactions_length; i++) {
-            const prompt = allModelsInteractions[0]?.interaction_json[i]?.prompt;
+            const prompt = allModelsInteractions.find(
+              (m) => m?.interaction_json?.[i]?.prompt
+            )?.interaction_json?.[i]?.prompt;
             const modelOutputs = [];
             let turnPromptOutputPairId = null;
 
@@ -910,8 +944,8 @@ const MultipleLLMInstructionDrivenChat = ({
                 if (!response_valid) {
                   setIsModelFailing(true);
                 }
-                if (modelIdx === 0) {
-                  turnPromptOutputPairId = interaction?.prompt_output_pair_id;
+                if (interaction?.prompt_output_pair_id) {
+                  turnPromptOutputPairId = interaction.prompt_output_pair_id;
                 }
                 modelOutputs.push({
                   model_id: modelData?.model_id || modelData?.model_name,


### PR DESCRIPTION
## Description of the Problem
In the **Multiple LLM Instruction Driven Chat** feature, users experienced a critical bug where both the prompt and the streamed model response would abruptly disappear from the UI immediately after the streaming sequence completed. 

This issue was caused by fragile alignment logic when mapping the responses of multiple models into the UI's `chatHistory` state. The previous implementation assumed that all models always had the exact same number of interaction turns, relying solely on the length of the first model's `interaction_json` array and using a strict index `i` to map across all other models. If one model failed to generate a response, timed out, or skipped a turn, its interaction array became misaligned with the others. Consequently, re-fetching the updated data resulted in undefined prompts and dropped pairs, causing the UI to break and hide the answers.

## Proposed Solution
This PR refactors the interaction mapping logic across all major Multiple LLM chat stages to be robust and fault-tolerant. 

**Key changes include:**
- **Dynamic Interaction Length Mapping**: Replaced the reliance on `allModelsInteractions[0].length`. The iteration count is now dynamically calculated using `Math.max` across all models' interaction array lengths.
- **Robust Prompt Retrieval**: Instead of assuming the prompt always exists at index `i` on the first model, the frontend now uses `.find()` to locate the first valid prompt available for the given turn across the model array.
- **Improved Misalignment Handling**: If a specific model is missing an interaction or failed to generate an output for a specific turn, the system correctly isolates that failure, injecting a placeholder error for that model rather than breaking the sequence for the successful models. 
- **Standardized extraction**: Applied this robust alignment strategy to `MultipleLLMInstructionDrivenChat.jsx` (for standard interaction/streaming) and its deletion handlers, as well as the deletion logic inside `AnnotatePage.jsx`, `ReviewPage.jsx`, and `SuperCheckerPage.jsx`.

## How to Test
1. Start the Anudesh Frontend environment.
2. Navigate to a Multiple LLM task (e.g., in Annotation, Review, or SuperChecker mode).
3. Ensure that one of the models fails or does not respond, while another succeeds.
4. Input a prompt and wait for the streaming to complete.
5. **Verify:** The prompt and the successfully generated answers should remain visible on the screen, and the failing model should correctly display a failure state instead of dropping the entire turn.

## Files Changed
- `src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx`
- `src/app/ui/pages/chat/AnnotatePage.jsx`
- `src/app/ui/pages/chat/ReviewPage.jsx`
- `src/app/ui/pages/chat/SuperCheckerPage.jsx`
