### PR TITLE
Fix prompt disappearing on back navigation before streaming starts

### DIFF
--- a/src/app/ui/pages/chat/InstructionDrivenChatPage.js
+++ b/src/app/ui/pages/chat/InstructionDrivenChatPage.js
@@ -155,6 +155,19 @@ const InstructionDrivenChatPage = ({
   const [loadtime, setloadtime] = useState(new Date());
   const load_time = useRef();
   const { streamResponse, abortStream } = useStreamingLLM();
+
+  // Abort any in-flight stream when the page unmounts (e.g. browser back).
+  // Otherwise the detached stream keeps running, completes in the background,
+  // and its completion handler removes the `in_progress_chat_single_${taskId}`
+  // recovery key (and PATCHes the server). Returning before the server refetch
+  // would then find no recovery breadcrumb, so the prompt vanishes until a
+  // manual refresh. Aborting keeps the breadcrumb so recovery can restore it.
+  useEffect(() => {
+    return () => {
+      abortStream();
+    };
+  }, [abortStream]);
+
   const [isDragging, setIsDragging] = useState(false);
 const [instructionWidth, setInstructionWidth] = useState(30);
 const [isPinned, setIsPinned] = useState(false);

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -169,6 +169,18 @@ const MultipleLLMInstructionDrivenChat = ({
   const [loadtime, setloadtime] = useState(new Date());
   const { streamMultiModelResponse, abortStream } = useStreamingLLM();
 
+  // Abort any in-flight stream when the page unmounts (e.g. browser back).
+  // Otherwise the detached stream keeps running, completes in the background,
+  // and its completion handler removes the `in_progress_chat_${taskId}` recovery
+  // key (and PATCHes the server). Returning before the server refetch would then
+  // find no recovery breadcrumb, so the prompt vanishes until a manual refresh.
+  // Aborting keeps the breadcrumb so recovery can restore it.
+  useEffect(() => {
+    return () => {
+      abortStream();
+    };
+  }, [abortStream]);
+
   useEffect(() => {
     if (setIsModelStreaming) {
       setIsModelStreaming(isStreaming);


### PR DESCRIPTION
Abort the in-flight LLM stream when the chat page unmounts (e.g. browser back). Previously the stream detached and kept running after unmount; its completion handler removed the in_progress_chat recovery key from localStorage (and PATCHed the server). Returning to the page before the server refetch then found no recovery breadcrumb, so the submitted prompt vanished until a manual refresh.

Aborting on unmount preserves the localStorage breadcrumb so the existing recovery logic restores the prompt (and resends to regenerate the response) when the user comes back. Applied to both the single-LLM and multi-LLM instruction-driven chat pages.