### PR TITLE
Fix chat recovery duplicate + disable delete/retry during streaming

### DIFF
--- a/src/app/ui/pages/chat/InstructionDrivenChatPage.js
+++ b/src/app/ui/pages/chat/InstructionDrivenChatPage.js
@@ -954,6 +954,10 @@ const renderChatHistory = () => {
                   <IconButton
                     size="small"
                     onClick={() => handleClick("delete-pair", id?.id, 0.0)}
+                    // Disable while a response is streaming: an in-flight stream
+                    // would re-save the turn on completion and silently undo the
+                    // delete. Re-enabled once streaming finishes.
+                    disabled={isStreaming || chatLoading || loading}
                     style={{
                       padding: "4px",
                     }}

--- a/src/app/ui/pages/chat/InstructionDrivenChatPage.js
+++ b/src/app/ui/pages/chat/InstructionDrivenChatPage.js
@@ -937,7 +937,9 @@ const renderChatHistory = () => {
                   <IconButton
                     size="small"
                     onClick={() => handleButtonClick(message.prompt, true)}
-                    disabled={loading}
+                    // Match delete: block retry while a response is streaming so
+                    // an in-flight stream can't clash with a re-send.
+                    disabled={isStreaming || chatLoading || loading}
                     style={{
                       padding: "4px",
                     }}

--- a/src/app/ui/pages/chat/InstructionDrivenChatPage.js
+++ b/src/app/ui/pages/chat/InstructionDrivenChatPage.js
@@ -364,16 +364,16 @@ const [snackbar, setSnackbarInfo] = useState({
         );
 
        if (!serverTurnWithValidResponse) {
-  try {
-    const parsedLocal = JSON.parse(localInProgress);
-
-    if (parsedLocal?.length > 0) {
-      modifiedChatHistory = parsedLocal;
-      setChatHistory(parsedLocal);
-    }
-  } catch (e) {
-    console.error(e);
-  }
+  // The last recovered turn is the in-progress prompt whose response never
+  // finished streaming. Display only the already-completed prior turns and let
+  // the resend below re-append this prompt, so it renders once (streaming into a
+  // single turn) instead of twice — once as an empty-response placeholder and
+  // again as the streamed resend. Keeping it here would also duplicate it in the
+  // stream history and PATCH payload, which handleButtonClick builds from
+  // chatHistory assuming it holds previous turns only.
+  const priorTurns = Array.isArray(parsedLocal) ? parsedLocal.slice(0, -1) : [];
+  modifiedChatHistory = priorTurns;
+  setChatHistory(priorTurns);
 
   setIsStreaming(true);
   setIsPolling(true);

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -484,19 +484,13 @@ if (localInProgress) {
     if (!serverTurnWithValidResponse) {
       const lastPromptToResend = lastLocalPrompt;
 
-     try {
-  const parsedLocal = JSON.parse(localInProgress);
-
-  if (parsedLocal?.length > 0) {
-    modifiedChatHistory = parsedLocal;
-    setChatHistory(parsedLocal);
-  }
-} catch (e) {
-  console.error(e);
-}
-
-setIsStreaming(true);
-setIsPolling(true);
+      // Drop the in-progress last turn (its response never finished streaming)
+      // so the resend below re-appends it once, instead of rendering the prompt
+      // twice — once as an empty-response placeholder and again as the streamed
+      // resend.
+      const priorTurns = Array.isArray(parsedLocal) ? parsedLocal.slice(0, -1) : [];
+      modifiedChatHistory = priorTurns;
+      setChatHistory(priorTurns);
 
       setIsStreaming(false);
       setIsPolling(false);

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -2035,6 +2035,10 @@ if (localInProgress) {
                 {index === chatHistory.length - 1 && stage !== "Alltask" && !disableUpdateButton && (
                   <IconButton
                     size="small"
+                    // Disable while a response is streaming: an in-flight stream
+                    // would re-save the turn on completion and silently undo the
+                    // delete. Re-enabled once streaming finishes.
+                    disabled={isStreaming || chatLoading || loading}
                     style={{
                       padding: "4px"
                     }}

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -2025,7 +2025,9 @@ if (localInProgress) {
                         padding: "4px",
                       }}
                       onClick={handleRetry}
-                      disabled={loading}
+                      // Match delete: block retry while a response is streaming so
+                      // an in-flight stream can't clash with a re-send.
+                      disabled={isStreaming || chatLoading || loading}
                     >
                       <RestartAltIcon style={{ color: "#EE6633", fontSize: "0.9rem" }} />
                     </IconButton>


### PR DESCRIPTION
## Summary

Follow-up fixes to the back-navigation / streaming-recovery behavior in the instruction-driven chat pages. Builds on the earlier abort-on-unmount fix (commit 130acbc6, already in `develop`), which kept the in-progress prompt's recovery breadcrumb in `localStorage` so it can be restored on return.

This PR contains three fixes, applied to both the single-LLM (`InstructionDrivenChatPage.js`) and multi-LLM (`MultipleLLMInstructionDrivenChat.jsx`) pages:

### 1. Fix duplicate prompt on recovery after back navigation
On return, recovery restored the **full** in-progress history — including the last turn whose response never finished — and the resend then **re-appended** that same prompt, so it rendered twice (once as an empty-response placeholder, once as the streaming resend). In the single-LLM page it would also have been duplicated in the stream context and PATCH payload, which `handleButtonClick` builds from `chatHistory` assuming it holds *previous turns only*. Fix: restore only the already-completed prior turns and let the resend re-append the in-progress prompt exactly once.

### 2. Disable delete while a response is streaming
Deleting a pair mid-stream had no effect: the in-flight stream kept writing the turn back into `chatHistory` and, on completion, PATCHed the full history to the server — silently re-creating the deleted pair. Delete is now disabled until streaming finishes.

### 3. Disable retry while a response is streaming
The retry button used `disabled={loading}`, but the parent `loading` prop is not set during streaming, so retry stayed clickable mid-stream and could clash with the in-flight stream. It now uses the same streaming-aware condition as delete (`isStreaming || chatLoading || loading`).

## Testing
Verified by code analysis (scope, data flow, brace balance); no lint/build tooling was available in the working environment. A manual pass over the streaming flows — back navigation, delete during stream, retry during stream — is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
