### PR TITLE
Grey out delete/retry icons when disabled during streaming

### DIFF
--- a/src/app/ui/pages/chat/InstructionDrivenChatPage.js
+++ b/src/app/ui/pages/chat/InstructionDrivenChatPage.js
@@ -770,6 +770,12 @@ onToken: (token, fullText) => {
 
 const renderChatHistory = () => {
 
+    // Delete/retry are disabled while a response is streaming; grey the icons to
+    // match so they visibly read as unavailable (their hardcoded orange would
+    // otherwise override MUI's disabled dimming).
+    const actionsDisabled = isStreaming || chatLoading || loading;
+    const actionIconColor = actionsDisabled ? grey[300] : "#EE6633";
+
     const toggleShrink = (index) => {
         setShrinkedMessages(prev => ({
             ...prev,
@@ -939,12 +945,12 @@ const renderChatHistory = () => {
                     onClick={() => handleButtonClick(message.prompt, true)}
                     // Match delete: block retry while a response is streaming so
                     // an in-flight stream can't clash with a re-send.
-                    disabled={isStreaming || chatLoading || loading}
+                    disabled={actionsDisabled}
                     style={{
                       padding: "4px",
                     }}
                   >
-                    <RestartAltIcon style={{ fontSize: "1rem", color: "#EE6633" }} />
+                    <RestartAltIcon style={{ fontSize: "1rem", color: actionIconColor }} />
                   </IconButton>
                 </Tooltip>
               )}
@@ -959,13 +965,13 @@ const renderChatHistory = () => {
                     // Disable while a response is streaming: an in-flight stream
                     // would re-save the turn on completion and silently undo the
                     // delete. Re-enabled once streaming finishes.
-                    disabled={isStreaming || chatLoading || loading}
+                    disabled={actionsDisabled}
                     style={{
                       padding: "4px",
                     }}
                   >
                     <DeleteOutlinedIcon
-                      style={{ color: "#EE6633", fontSize: "1rem" }}
+                      style={{ color: actionIconColor, fontSize: "1rem" }}
                     />
                   </IconButton>
                 )}

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -1822,6 +1822,12 @@ if (localInProgress) {
   };
 
   const renderChatHistory = () => {
+    // Delete/retry are disabled while a response is streaming; grey the icons to
+    // match so they visibly read as unavailable (their hardcoded orange would
+    // otherwise override MUI's disabled dimming).
+    const actionsDisabled = isStreaming || chatLoading || loading;
+    const actionIconColor = actionsDisabled ? grey[300] : "#EE6633";
+
     const toggleShrink = (index) => {
       setShrinkedMessages(prev => ({ ...prev, [index]: !prev[index] }));
     };
@@ -2027,9 +2033,9 @@ if (localInProgress) {
                       onClick={handleRetry}
                       // Match delete: block retry while a response is streaming so
                       // an in-flight stream can't clash with a re-send.
-                      disabled={isStreaming || chatLoading || loading}
+                      disabled={actionsDisabled}
                     >
-                      <RestartAltIcon style={{ color: "#EE6633", fontSize: "0.9rem" }} />
+                      <RestartAltIcon style={{ color: actionIconColor, fontSize: "0.9rem" }} />
                     </IconButton>
                   </Tooltip>
                 )}
@@ -2040,7 +2046,7 @@ if (localInProgress) {
                     // Disable while a response is streaming: an in-flight stream
                     // would re-save the turn on completion and silently undo the
                     // delete. Re-enabled once streaming finishes.
-                    disabled={isStreaming || chatLoading || loading}
+                    disabled={actionsDisabled}
                     style={{
                       padding: "4px"
                     }}
@@ -2063,7 +2069,7 @@ if (localInProgress) {
                       handleClick("delete-pair", id?.id, 0.0, "MultipleLLMInstructionDrivenChat");
                     }}
                   >
-                    <DeleteOutlinedIcon style={{ color: "#EE6633", fontSize: "0.9rem" }} />
+                    <DeleteOutlinedIcon style={{ color: actionIconColor, fontSize: "0.9rem" }} />
                   </IconButton>
                 )}
               </Grid>


### PR DESCRIPTION
## Summary

Follow-up to #701 (merged). The delete and retry buttons are disabled while a response is streaming, but their icons had a hardcoded orange color applied via inline `style`, which overrode MUI's built-in disabled dimming — so they still looked active when disabled.

This drives the icon color from the same disabled condition, so the icons render greyed out (`grey[300]`) while streaming and revert to orange (`#EE6633`) once it finishes:

```js
const actionsDisabled = isStreaming || chatLoading || loading;
const actionIconColor = actionsDisabled ? grey[300] : "#EE6633";
```

Applied to both the single-LLM (`InstructionDrivenChatPage.js`) and multi-LLM (`MultipleLLMInstructionDrivenChat.jsx`) instruction-driven chat pages.

## Testing
Verified by code analysis; no lint/build tooling was available in the working environment. A quick visual check during a live stream is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
