### PR TITLE
Add copy-prompt button to chat turns

### DIFF
--- a/src/app/ui/pages/chat/InstructionDrivenChatPage.js
+++ b/src/app/ui/pages/chat/InstructionDrivenChatPage.js
@@ -36,6 +36,7 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CodeIcon from '@mui/icons-material/Code';
 import AssignmentIcon from '@mui/icons-material/Assignment';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import PushPinIcon from '@mui/icons-material/PushPin';
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
@@ -922,6 +923,19 @@ const renderChatHistory = () => {
                 flexShrink: 0,
               }}
             >
+              {/* Copy prompt button */}
+              <Tooltip title="Copy prompt">
+                <IconButton
+                  size="small"
+                  onClick={() => copyToClipboard(message?.prompt || "")}
+                  style={{
+                    padding: "4px",
+                  }}
+                >
+                  <ContentCopyIcon style={{ fontSize: "1rem", color: "#EE6633" }} />
+                </IconButton>
+              </Tooltip>
+
               {/* Shrink button */}
               <IconButton
                 size="small"

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -47,6 +47,7 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CodeIcon from '@mui/icons-material/Code';
 import AssignmentIcon from '@mui/icons-material/Assignment';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import PushPinIcon from '@mui/icons-material/PushPin';
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
@@ -562,6 +563,23 @@ if (localInProgress) {
   function isString(value) {
     return typeof value === "string" || value instanceof String;
   }
+
+  const copyToClipboard = async (text) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setSnackbarInfo({
+        open: true,
+        message: "Copied to clipboard!",
+        variant: "success",
+      });
+    } catch (error) {
+      setSnackbarInfo({
+        open: true,
+        message: "Failed to copy to clipboard!",
+        variant: "error",
+      });
+    }
+  };
 
   const generateUniquePromptOutputPairId = () => {
     const time = Date.now();
@@ -2008,6 +2026,19 @@ if (localInProgress) {
                   flexShrink: 0,
                 }}
               >
+
+                {/* Copy prompt button */}
+                <Tooltip title="Copy prompt">
+                  <IconButton
+                    size="small"
+                    onClick={() => copyToClipboard(message?.prompt || "")}
+                    style={{
+                      padding: "4px"
+                    }}
+                  >
+                    <ContentCopyIcon style={{ fontSize: "0.9rem", color: "#EE6633" }} />
+                  </IconButton>
+                </Tooltip>
 
                 <IconButton
                   size="small"


### PR DESCRIPTION
## Summary

Adds a **copy-prompt** button to each chat turn in the instruction-driven chat pages.

- A copy icon sits next to each prompt's shrink/expand control, so it's available on **every** turn (not just the last).
- Clicking it copies the prompt text to the clipboard and shows a success/failure snackbar.
- Always enabled (copying is safe during streaming).
- Added the shared `copyToClipboard` helper to the multi-LLM page (the single-LLM page already had one).

Applied to both `InstructionDrivenChatPage.js` and `MultipleLLMInstructionDrivenChat.jsx`.

## Notes
- `copyToClipboard` uses the async Clipboard API, which requires a secure context (HTTPS / localhost) — fine for deployed and dev setups.

## Testing
Verified by code analysis; no lint/build tooling was available in the working environment. A quick click-test is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
