### PR TITLE
fix(isErrorOutput): prevent false-positive error flags on responses containing error substrings

### DIFF
--- a/src/app/ui/pages/chat/AnnotatePage.jsx
+++ b/src/app/ui/pages/chat/AnnotatePage.jsx
@@ -132,13 +132,13 @@ const AnnotatePage = () => {
 
   const isErrorOutput = (value) => {
     if (typeof value !== "string") return false;
-    const lower = value.toLowerCase();
+    const lower = value.toLowerCase().trim();
     return (
       lower.startsWith("[error]") ||
-      lower.includes("temporarily unavailable") ||
-      lower.includes("encountered an error") ||
-      lower.includes("streaming timed out") ||
-      lower.includes("failed to generate a response")
+      lower.startsWith("the model is temporarily unavailable") ||
+      lower.startsWith("encountered an error") ||
+      lower.startsWith("streaming timed out") ||
+      lower.startsWith("failed to generate a response")
     );
   };
 

--- a/src/app/ui/pages/chat/InstructionDrivenChatPage.js
+++ b/src/app/ui/pages/chat/InstructionDrivenChatPage.js
@@ -161,13 +161,13 @@ const FontSizeSlider = memo(({ value, containerRef, onCommit, onReset }) => {
 
 const isErrorOutput = (value) => {
   if (typeof value !== "string") return false;
-  const lower = value.toLowerCase();
+  const lower = value.toLowerCase().trim();
   return (
     lower.startsWith("[error]") ||
-    lower.includes("temporarily unavailable") ||
-    lower.includes("encountered an error") ||
-    lower.includes("streaming timed out") ||
-    lower.includes("failed to generate a response")
+    lower.startsWith("the model is temporarily unavailable") ||
+    lower.startsWith("encountered an error") ||
+    lower.startsWith("streaming timed out") ||
+    lower.startsWith("failed to generate a response")
   );
 };
 

--- a/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
+++ b/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx
@@ -174,15 +174,16 @@ const FontSizeSlider = memo(({ value, containerRef, onCommit, onReset }) => {
 
 const isErrorOutput = (value) => {
   if (typeof value !== "string") return false;
-  const lower = value.toLowerCase();
+  const lower = value.toLowerCase().trim();
   return (
     lower.startsWith("[error]") ||
-    lower.includes("temporarily unavailable") ||
-    lower.includes("encountered an error") ||
-    lower.includes("streaming timed out") ||
-    lower.includes("failed to generate a response")
+    lower.startsWith("the model is temporarily unavailable") ||
+    lower.startsWith("encountered an error") ||
+    lower.startsWith("streaming timed out") ||
+    lower.startsWith("failed to generate a response")
   );
 };
+
 
 const reverseFormatResponse = (formattedOutput) => {
   let response = "";


### PR DESCRIPTION
## Description
 **False-Positive Error Validation**: Fixes a bug where normal model responses containing error-like phrases (e.g. *"temporarily unavailable"*) were incorrectly flagged as failed turns, permanently locking the Submit button.

---

## Key Changes

### Strict Error Substring Matching (`isErrorOutput`)
* **The Issue**: The `isErrorOutput` helper loosely checked for substring matches (e.g., `.includes("temporarily unavailable")`). If a model response naturally used any of these phrases (e.g. *"The online service might be temporarily unavailable..."*), the turn was false-positively marked as a failed response, greying out the Submit button.
* **The Fix**: 
  * Changed loose `.includes()` checks to strict `.startsWith()` matching for error strings in [AnnotatePage.jsx](file:///d:/Anudesh/Anudesh-Frontend/src/app/ui/pages/chat/AnnotatePage.jsx), [InstructionDrivenChatPage.js](file:///d:/Anudesh/Anudesh-Frontend/src/app/ui/pages/chat/InstructionDrivenChatPage.js), and [MultipleLLMInstructionDrivenChat.jsx](file:///d:/Anudesh/Anudesh-Frontend/src/app/ui/pages/multiple-llm-idcp/MultipleLLMInstructionDrivenChat.jsx).

