### PR TITLE
fixed negative integers apperaing on the chart y-axis

### DIFF
--- a/src/app/ui/pages/progress/PerformanaceAnalytics/PerformanceAnalytics.jsx
+++ b/src/app/ui/pages/progress/PerformanaceAnalytics/PerformanceAnalytics.jsx
@@ -96,6 +96,7 @@ const options = {
     y: {
       stacked: true,
       display: true,
+      beginAtZero: true,
       title: {
         display: true,
         text: "Compleated Count",

--- a/src/app/ui/pages/progress/Workspace/PerformanceAnalytics.jsx
+++ b/src/app/ui/pages/progress/Workspace/PerformanceAnalytics.jsx
@@ -96,6 +96,7 @@ const options = {
     y: {
       stacked: true,
       display: true,
+      beginAtZero: true,
       title: {
         display: true,
         text: "Compleated Count",


### PR DESCRIPTION
- Add `beginAtZero: true` to the chart's y-axis in both PerformanceAnalytics
  pages (org-level and workspace-level).
- Fixes negative/positive integer ticks appearing when a selected range has
  no completed tasks.