### PR TITLE
feat(reports): add multi-select for project types and CSV download in workspace payment reports

### DIFF
--- a/src/Lib/Features/projects/DownloadWorkspacePaymentReport.js
+++ b/src/Lib/Features/projects/DownloadWorkspacePaymentReport.js
@@ -1,0 +1,69 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import fetchParams from '../../fetchParams';
+import ENDPOINTS from "../../../config/apiendpoint"
+
+const initialState = {
+  data: 0,
+  status: 'idle',
+  error: null,
+};
+
+const triggerCsvDownload = (content, filename) => {
+  const downloadLink = document.createElement("a");
+  const blob = new Blob(["﻿", content], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  downloadLink.href = url;
+  downloadLink.download = filename;
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  document.body.removeChild(downloadLink);
+  URL.revokeObjectURL(url);
+};
+
+export const fetchDownloadWorkspacePaymentReport = createAsyncThunk(
+  'DownloadWorkspacePaymentReport/fetchDownloadWorkspacePaymentReport',
+  async ({ orgId, userId, projectType, participationTypes, fromDate, toDate }) => {
+    const body = {
+      project_type: projectType,
+      participation_types: participationTypes,
+      user_id: userId,
+      from_date: fromDate,
+      to_date: toDate,
+      download_csv: true,
+    };
+    const params = fetchParams(`${ENDPOINTS.getWorkspaces}${orgId}/send_user_analytics/`, "POST", JSON.stringify(body));
+    const response = await fetch(params.url, params.options);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || "Failed to download report");
+    }
+    const disposition = response.headers.get("Content-Disposition");
+    const match = disposition && disposition.match(/filename="?([^"]+)"?/);
+    const filename = match ? match[1] : "payment_report.csv";
+    const content = await response.text();
+    return { content, filename };
+  }
+);
+
+const DownloadWorkspacePaymentReport = createSlice({
+  name: 'DownloadWorkspacePaymentReport',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchDownloadWorkspacePaymentReport.pending, (state) => {
+        state.status = 'loading';
+      })
+      .addCase(fetchDownloadWorkspacePaymentReport.fulfilled, (state, action) => {
+        state.status = 'succeeded';
+        triggerCsvDownload(action.payload.content, action.payload.filename);
+        state.data += 1;
+      })
+      .addCase(fetchDownloadWorkspacePaymentReport.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.error.message;
+      });
+  },
+});
+
+export default DownloadWorkspacePaymentReport.reducer;

--- a/src/Lib/Store.js
+++ b/src/Lib/Store.js
@@ -69,6 +69,7 @@ import getDomain from './Features/actions/getDomain';
 import taskPaginationSlice from './Features/user/taskPaginationSlice'
 import EditOrganization from './Features/user/EditOrganization';
 import SendWorkspaceUserReports from './Features/projects/SendWorkspaceUserReports';
+import DownloadWorkspacePaymentReport from './Features/projects/DownloadWorkspacePaymentReport';
 import WorkspaceUserReports from './Features/projects/WorkspaceUserReports';
 import WorkspaceProjectReport from './Features/projects/WorkspaceProjectReport';
 import GetExportProjectButton from './Features/datasets/GetExportProjectButton';
@@ -89,6 +90,7 @@ const makeStore = () => {
         WorkspaceProjectReport:WorkspaceProjectReport,
         WorkspaceUserReports:WorkspaceUserReports,
         SendWorkspaceUserReports:SendWorkspaceUserReports,
+        DownloadWorkspacePaymentReport:DownloadWorkspacePaymentReport,
         EditOrganization:EditOrganization,
         getTaskDetails:getTaskDetails,
         AddGlossary:AddGlossary,

--- a/src/components/common/WorkspaceReports.jsx
+++ b/src/components/common/WorkspaceReports.jsx
@@ -12,6 +12,8 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
+import Checkbox from "@mui/material/Checkbox";
+import ListItemText from "@mui/material/ListItemText";
 import Skeleton from "@mui/material/Skeleton";
 import RadioGroup from "@mui/material/RadioGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -34,6 +36,7 @@ import { fetchWorkspaceUserReports } from "@/Lib/Features/projects/WorkspaceUser
 import { fetchWorkspaceProjectReport } from "@/Lib/Features/projects/WorkspaceProjectReport";
 import { fetchWorkspaceDetailedProjectReports } from "@/Lib/Features/projects/WorkspaceDetailedProjectReports";
 import { fetchSendWorkspaceUserReports } from "@/Lib/Features/projects/SendWorkspaceUserReports";
+import { fetchDownloadWorkspacePaymentReport } from "@/Lib/Features/projects/DownloadWorkspacePaymentReport";
 import { styled } from "@mui/material/styles";
 import TablePagination from "@mui/material/TablePagination";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -128,7 +131,7 @@ const WorkspaceReports = () => {
   const [projectType, setProjectType] = useState({
     user: "InstructionDrivenChat",
     project: "InstructionDrivenChat",
-    payment: "InstructionDrivenChat",
+    payment: ["InstructionDrivenChat"],
   });
   const [targetLanguage, setTargetLanguage] = useState({
     user: "all",
@@ -600,6 +603,15 @@ const WorkspaceReports = () => {
   const handleDateSubmit = (sendMail) => {
     setLoading(true);
     if (radioButton === "payment") {
+      if (!projectType[radioButton]?.length) {
+        setSnackbarInfo({
+          open: true,
+          message: "Please select at least one Project Type",
+          variant: "error",
+        });
+        setLoading(false);
+        return;
+      }
       dispatch(
         fetchSendWorkspaceUserReports({
           orgId: id,
@@ -690,6 +702,44 @@ const WorkspaceReports = () => {
         }
       }
     }
+  };
+
+  const handleDownloadCsv = () => {
+    if (!projectType[radioButton]?.length) {
+      setSnackbarInfo({
+        open: true,
+        message: "Please select at least one Project Type",
+        variant: "error",
+      });
+      return;
+    }
+    setLoading(true);
+    dispatch(
+      fetchDownloadWorkspacePaymentReport({
+        orgId: id,
+        userId: UserDetails.id,
+        projectType: projectType[radioButton],
+        participationTypes: participationTypes,
+        fromDate: format(selectRange[0]?.startDate, "yyyy-MM-dd"),
+        toDate: format(selectRange[0]?.endDate, "yyyy-MM-dd"),
+      }),
+    )
+      .unwrap()
+      .then(() => {
+        setSnackbarInfo({
+          open: true,
+          message: "Report downloaded successfully",
+          variant: "success",
+        });
+      })
+      .catch((error) => {
+        setSnackbarInfo({
+          open: true,
+          message: error?.message || "Failed to download report",
+          variant: "error",
+        });
+      })
+      .finally(() => setLoading(false));
   };
 
   const handleChangeprojectFilter = (event) => {
@@ -838,21 +888,72 @@ const WorkspaceReports = () => {
             <Select
               labelId="project-type-label"
               id="project-type-select"
+              multiple={radioButton === "payment"}
               value={projectType[radioButton]}
               label="Project Type"
+              renderValue={
+                radioButton === "payment"
+                  ? (selected) => selected.join(", ")
+                  : undefined
+              }
               onChange={(e) => {
                 setProjectType({
                   ...projectType,
                   [radioButton]: e.target.value,
                 });
               }}
-              MenuProps={MenuProps}
+              MenuProps={{
+                ...MenuProps,
+                PaperProps: {
+                  ...MenuProps.PaperProps,
+                  style: {
+                    ...MenuProps.PaperProps.style,
+                    overflowX: "auto",
+                  },
+                  sx: {
+                    "&::-webkit-scrollbar": {
+                      height: "4px",
+                      width: "4px",
+                    },
+                    "&::-webkit-scrollbar-track": {
+                      background: "transparent",
+                    },
+                    "&::-webkit-scrollbar-thumb": {
+                      background: "#c9c7c7",
+                      borderRadius: "20px",
+                    },
+                    "&::-webkit-scrollbar-thumb:hover": {
+                      background: "#a6a4a4",
+                    },
+                  },
+                },
+              }}
             >
-              {projectTypes.map((type, index) => (
-                <MenuItem value={type} key={index}>
-                  {type}
-                </MenuItem>
-              ))}
+              {projectTypes.map((type, index) =>
+                radioButton === "payment" ? (
+                  <MenuItem
+                    value={type}
+                    key={index}
+                    sx={{ whiteSpace: "nowrap" }}
+                  >
+                    <Checkbox
+                      checked={projectType[radioButton].indexOf(type) > -1}
+                    />
+                    <ListItemText
+                      primary={type}
+                      primaryTypographyProps={{ sx: { whiteSpace: "nowrap" } }}
+                    />
+                  </MenuItem>
+                ) : (
+                  <MenuItem
+                    value={type}
+                    key={index}
+                    sx={{ whiteSpace: "nowrap" }}
+                  >
+                    {type}
+                  </MenuItem>
+                ),
+              )}
             </Select>
           </FormControl>
         </Grid>
@@ -1008,6 +1109,18 @@ const WorkspaceReports = () => {
             E-mail CSV
           </Button>
         </Grid>
+        {radioButton === "payment" && (
+          <Grid item xs={12} sm={12} md={3} lg={3} xl={3}>
+            <Button
+              fullWidth
+              variant="contained"
+              onClick={handleDownloadCsv}
+              sx={{ width: "170px", whiteSpace: "nowrap" }}
+            >
+              Download CSV
+            </Button>
+          </Grid>
+        )}
       </Grid>
       {showPicker && (
         <Box


### PR DESCRIPTION
## Description

This PR introduces enhancements to the Workspace Payment Reports functionality. Users can now combine multiple project types into a single payment report and download the CSV directly from the UI, bypassing the need to wait for an email.

### New Features & Enhancements

**Frontend**
- **Multi-Select for Project Types:** Upgraded the "Project Type" dropdown in the Workspace Reports view to support multi-selection (checkboxes) when the "payment" report option is selected.
- **Direct CSV Download:** Added a new "Download CSV" button alongside the existing "E-mail CSV" option for payment reports. This triggers a synchronous API call to instantly download the generated report to the user's device.
- **Redux Integration:** Introduced the `DownloadWorkspacePaymentReport` action and slice to handle the CSV download API request and file blob parsing.

**[Backend](https://github.com/AI4Bharat/Anudesh-Backend/pull/370)**
- **Multi-Project Support:** Updated the workspace reports API to accept `project_type` as a list of strings, allowing the report generator to aggregate data across multiple project types in a single output.
- **Synchronous CSV Response:** Added support for a `download_csv` boolean flag in the request payload. When true, the API dynamically generates the report and returns it immediately in the HTTP response as `text/csv`, rather than dispatching a Celery task.
- **Code Refactoring:** Abstracted the core CSV generation logic into a new, reusable `build_workspace_payment_report_csv` function to support both asynchronous emails and synchronous direct downloads cleanly.

### UI Changes
* The "Project Type" dropdown now uses checkboxes for multiple selections when generating a payment report.
* A "Download CSV" button is now visible when the payment report radio button is active.

### Testing Instructions
1. Navigate to the Workspace Reports page and select the **Payment** report option.
2. Open the Project Type dropdown and select multiple project types.
3. Select a date range and click **Download CSV**.
4. Verify that the CSV file downloads successfully to your local machine and accurately reflects aggregated data for all selected project types.
5. Click **E-mail CSV** and verify that the asynchronous email functionality remains intact.
